### PR TITLE
fix for issue #24: wheel zoom over a point should not change the point position

### DIFF
--- a/qreal/qrgui/view/editorview.cpp
+++ b/qreal/qrgui/view/editorview.cpp
@@ -17,6 +17,8 @@ EditorView::EditorView(QWidget *parent)
 	connect(mScene, SIGNAL(zoomIn()), this, SLOT(zoomIn()));
 	connect(mScene, SIGNAL(zoomOut()), this, SLOT(zoomOut()));
 
+        setTransformationAnchor(QGraphicsView::AnchorUnderMouse);
+
 	mMVIface = new EditorViewMViface(this, mScene);
 	setScene(mScene);
 


### PR DESCRIPTION
fix for issue #24: wheel zoom over a point should not change the point position
