### PR TITLE
Fixed step resizing of NodeElement.

### DIFF
--- a/qrgui/umllib/nodeElement.cpp
+++ b/qrgui/umllib/nodeElement.cpp
@@ -503,8 +503,8 @@ void NodeElement::mouseMoveEvent(QGraphicsSceneMouseEvent *event)
 			parentPos = parItem->scenePos();
 		}
 
-		qreal const newX = mGrid->makeGridAlignment(event->pos().x());
-		qreal const newY = mGrid->makeGridAlignment(event->pos().y());
+		qreal const newX = event->pos().x();
+		qreal const newY = event->pos().y();
 
 		switch (mDragState) {
 		case TopLeft: {


### PR DESCRIPTION
Поправлен ресайз NodeElement. Теперь он не привязан к сетке.
Контейнер растягивается, но не двигается (только в особом, ниже описанном случае) при захвате за правый верхний и левый нижний углы.
Двигается, если дети у границы. Но это достаточно логично - мышка всегда у края контейнера при ей движении.

Возможные дальнейшие изменения (но не знаю, стоит ли это делать, хочу комментарии):
1) Сделать, чтобы дети оставались на месте, а не сохраняли расстояние до границы контейнера.
2) Убрать тот, особый случай, о котором говорится выше.
