### PR TITLE
Mad containers fix

### DIFF
--- a/qrgui/umllib/nodeElement.cpp
+++ b/qrgui/umllib/nodeElement.cpp
@@ -460,7 +460,7 @@ void NodeElement::mouseMoveEvent(QGraphicsSceneMouseEvent *event)
 
 	}
 
-	resize(newContents, newPos, mPos);
+	resize(newContents, newPos);
 
 	if (isPort()) {
 		mUmlPortHandler->handleMoveEvent(mLeftPressed, mPos, event->scenePos(), mParentNodeElement);
@@ -1136,18 +1136,18 @@ NodeData& NodeElement::data()
 
 void NodeElement::resize()
 {
-	resize(mContents, pos(), pos());
+	resize(mContents, pos());
 }
 
 void NodeElement::resize(QRectF const &newContents)
 {
-	resize(newContents, pos(), pos());
+	resize(newContents, pos());
 }
 
-void NodeElement::resize(QRectF const &newContents, QPointF const &newPos, QPointF const &oldPos)
+void NodeElement::resize(QRectF const &newContents, QPointF const &newPos)
 {
 	ResizeHandler handler(this);
-	handler.resize(newContents, newPos, oldPos);
+	handler.resize(newContents, newPos);
 }
 
 bool NodeElement::isFolded() const

--- a/qrgui/umllib/nodeElement.h
+++ b/qrgui/umllib/nodeElement.h
@@ -174,9 +174,8 @@ private:
 	 * in most cases.
 	 * @param newContents Recommendation for new shape of node.
 	 * @param newPos Recommendation for new position of node.
-	 * @param oldPos Old position in case we are in a container
 	 */
-	void resize(QRectF const &newContents, QPointF const &newPos, const QPointF &oldPos);
+	void resize(QRectF const &newContents, QPointF const &newPos);
 
 	/**
 	 * Calls resize(QRectF newContents, QPointF newPos) with

--- a/qrgui/umllib/private/resizeCommand.cpp
+++ b/qrgui/umllib/private/resizeCommand.cpp
@@ -75,7 +75,7 @@ void ResizeCommand::resize(NodeElement * const element, QRectF const &geometry)
 {
 	if (element && geometryOf(element) != geometry) {
 		ResizeHandler handler(element);
-		handler.resize(geometry.translated(-geometry.topLeft()), geometry.topLeft(), geometry.topLeft());
+		handler.resize(geometry.translated(-geometry.topLeft()), geometry.topLeft());
 	}
 }
 

--- a/qrgui/umllib/private/resizeHandler.cpp
+++ b/qrgui/umllib/private/resizeHandler.cpp
@@ -8,7 +8,7 @@ ResizeHandler::ResizeHandler(NodeElement * const resizingNode)
 {
 }
 
-void ResizeHandler::resize(QRectF newContents, QPointF newPos, QPointF const &oldPos) const
+void ResizeHandler::resize(QRectF newContents, QPointF newPos) const
 {
 	newContents.moveTo(0, 0);
 
@@ -27,19 +27,6 @@ void ResizeHandler::resize(QRectF newContents, QPointF newPos, QPointF const &ol
 	mTargetNode->setPos(newPos);
 
 	resizeParent();
-
-	/* If mTargetNode is inside a container and it's being moved towards top or left side of this container,
-	 * the container becomes to resize. And since mTargetNode->pos() is calculated in container's coord system
-	 * we get mTargetNode to move more when container resizes. The indicator of this case is negative value
-	 * of coord of newPos.x() or newPos.y(). In this case we get its old position back. That way visually it
-	 * will be moved only once — when the container resizes.
-	 */
-	if (newPos.x() < 0 || newPos.y() < 0) {
-		newContents.moveTo(oldPos);
-		mTargetNode->setGeometry(newContents);
-		mTargetNode->storeGeometry();
-		mTargetNode->setPos(oldPos);
-	}
 }
 
 qreal ResizeHandler::maxChildWidth() const
@@ -108,7 +95,7 @@ void ResizeHandler::resizeParent() const
 	NodeElement * const parItem = dynamic_cast<NodeElement* const>(mTargetNode->parentItem());
 	if (parItem) {
 		ResizeHandler const handler(parItem);
-		handler.resize(parItem->contentsRect(), parItem->pos(), parItem->pos());
+		handler.resize(parItem->contentsRect(), parItem->pos());
 	}
 }
 
@@ -137,7 +124,7 @@ void ResizeHandler::resizeAccordingToChildren(QRectF &newContents, QPointF &newP
 	*/
 
 	/// Vector of minimum negative XY child deflection from top left corner.
-	QPointF childDeflectionVector = childDeflection();
+	QPointF const childDeflectionVector = childDeflection();
 
 	moveChildren(-childDeflectionVector);
 	newPos += childDeflectionVector;

--- a/qrgui/umllib/private/resizeHandler.h
+++ b/qrgui/umllib/private/resizeHandler.h
@@ -22,9 +22,8 @@ public:
 	 * in most cases.
 	 * @param newContents Recommendation for new shape of node.
 	 * @param newPos Recommendation for new position of node.
-	 * @param oldPos Old position in case we are in a container
 	 */
-	void resize(QRectF newContents, QPointF newPos, const QPointF &oldPos) const;
+	void resize(QRectF newContents, QPointF newPos) const;
 
 private:
 	/// Padding that reserves space for title.


### PR DESCRIPTION
fixed #643. Поправлена только бага с растяжением, контейнер все равно схлопывается по размеру детей при переоткрытии диаграммы.
