### PR TITLE
Исправлен баг с добавлением итема в контейнер, использую меню линка от элемента, лежащего внутри того-же контейнера.

### DIFF
--- a/qrgui/view/editorViewScene.cpp
+++ b/qrgui/view/editorViewScene.cpp
@@ -436,6 +436,7 @@ qReal::Id EditorViewScene::createElement(QString const &str)
 {
 	qReal::Id result = createElement(str, mCreatePoint, true, &mLastCreatedWithEdgeCommand);
 	mLastCreatedWithEdge = getElem(result);
+	mShouldReparentItems = false;
 	return result;
 }
 


### PR DESCRIPTION
Иногда ошибочно вызывался mouseReleaseEvent для созданного из меню линка итема.
