### PR TITLE
fix issue #556

### DIFF
--- a/qrgui/view/copyPaste/pasteNodeCommand.cpp
+++ b/qrgui/view/copyPaste/pasteNodeCommand.cpp
@@ -1,4 +1,4 @@
-#include "pasteNodeCommand.h"
+﻿#include "pasteNodeCommand.h"
 #include "../../mainwindow/mainWindow.h"
 
 using namespace qReal::commands;
@@ -10,7 +10,8 @@ PasteNodeCommand::PasteNodeCommand(EditorViewScene *scene
 		, bool isGraphicalCopy
 		, QHash<Id, Id> *copiedIds)
 	: PasteCommand(scene, mvIface, offset, isGraphicalCopy, copiedIds)
-	, mNodeData(data), mNewPos(getNewPos()), mCreateCommand(NULL)
+	, mNodeData(data)
+	, mCreateCommand(NULL)
 {
 }
 
@@ -21,7 +22,8 @@ Id PasteNodeCommand::pasteNewInstance()
 	Id resultId = mResult;
 	if (!mCreateCommand) {
 		Id const typeId = mNodeData.id.type();
-		resultId = mScene->createElement(typeId.toString(), mNewPos, true, &mCreateCommand, false);
+		resultId = mScene->createElement(typeId.toString(), getNewPos(), true, &mCreateCommand, false
+				, vectorFromContainer());
 		mCreateCommand->redo();
 		mCopiedIds->insert(mNodeData.id, resultId);
 		addPreAction(mCreateCommand);
@@ -34,14 +36,16 @@ Id PasteNodeCommand::pasteGraphicalCopy()
 	Id resultId = mResult;
 	if (!mCreateCommand) {
 		mCreateCommand = new CreateElementCommand(
-				mMVIface->logicalAssistApi()
-				, mMVIface->graphicalAssistApi()
-				, mMVIface->rootId()
-				, mMVIface->rootId()
-				, mNodeData.logicalId
-				, true
-				, mMVIface->graphicalAssistApi()->name(mNodeData.id)
-				, mNewPos);
+			mMVIface->logicalAssistApi()
+			, mMVIface->graphicalAssistApi()
+			, mMVIface->rootId()
+			, newGraphicalParent()
+			, mNodeData.logicalId
+			, true
+			, mMVIface->graphicalAssistApi()->name(mNodeData.id)
+			, getNewGraphicalPos()
+			);
+
 		mCreateCommand->redo();
 		resultId = mCreateCommand->result();
 		mCopiedIds->insert(mNodeData.id, resultId);
@@ -63,7 +67,7 @@ void PasteNodeCommand::restoreElement()
 	mMVIface->graphicalAssistApi()->setProperties(logicalId, mNodeData.logicalProperties);
 	mMVIface->graphicalAssistApi()->setProperties(mResult, mNodeData.graphicalProperties);
 	if (mCopiedIds->contains(mNodeData.parentId)) {
-		mMVIface->graphicalAssistApi()->changeParent(mResult, mCopiedIds->value(mNodeData.parentId), mNewPos);
+		mMVIface->graphicalAssistApi()->changeParent(mResult, mCopiedIds->value(mNodeData.parentId), getNewPos());
 	}
 	NodeElement *element = mScene->getNodeById(mResult);
 	if (element) {
@@ -73,5 +77,23 @@ void PasteNodeCommand::restoreElement()
 
 QPointF PasteNodeCommand::getNewPos() const
 {
-	return mNodeData.pos + (mCopiedIds->contains(mNodeData.parentId) ? QPointF() : mOffset);
+	return mNodeData.pos + (mCopiedIds->contains(mNodeData.parentId) ?
+			mMVIface->graphicalAssistApi()->position(mCopiedIds->value(mNodeData.parentId)) : mOffset);
+}
+
+QPointF PasteNodeCommand::getNewGraphicalPos() const
+{
+	return mNodeData.pos + (mCopiedIds->contains(mNodeData.parentId) ?
+			QPointF() : mOffset);
+}
+
+Id PasteNodeCommand::newGraphicalParent() const
+{
+	return (mCopiedIds->contains(mNodeData.parentId) ?
+			mCopiedIds->value(mNodeData.parentId) : mMVIface->rootId());
+}
+
+QPointF PasteNodeCommand::vectorFromContainer() const
+{
+	return (mNodeData.parentId == Id::rootId()) ? QPointF() : mNodeData.pos;
 }

--- a/qrgui/view/copyPaste/pasteNodeCommand.h
+++ b/qrgui/view/copyPaste/pasteNodeCommand.h
@@ -1,4 +1,4 @@
-#pragma once
+﻿#pragma once
 
 #include "pasteCommand.h"
 #include "../../controller/commands/createElementCommand.h"
@@ -25,10 +25,15 @@ protected:
 	virtual void restoreElement();
 
 private:
+	//! @returns real new pos on scene
 	QPointF getNewPos() const;
+	//! @returns pos for normal CreateElementCommand usage
+	QPointF getNewGraphicalPos() const;
+	Id newGraphicalParent() const;
+
+	QPointF vectorFromContainer() const;
 
 	NodeData const mNodeData;
-	QPointF const mNewPos;
 	CreateElementCommand *mCreateCommand;
 };
 

--- a/qrgui/view/editorViewScene.h
+++ b/qrgui/view/editorViewScene.h
@@ -1,4 +1,4 @@
-#pragma once
+﻿#pragma once
 
 #include <QtWidgets/QGraphicsScene>
 #include <QtWidgets/QGraphicsLineItem>
@@ -39,10 +39,14 @@ public:
 
 	virtual int launchEdgeMenu(EdgeElement *edge, NodeElement *node, const QPointF &scenePos
 			, commands::CreateElementCommand **elementCommand = 0);
-	virtual qReal::Id createElement(QString const &, QPointF const &scenePos
+	//! @arg shiftToParent vector from (0,0) of container Node to new Element (aka localPos)
+	virtual qReal::Id createElement(QString const &
+			, QPointF const &scenePos
 			, bool searchForParents = true
 			, commands::CreateElementCommand **createCommand = 0
-			, bool executeImmediately = true);
+			, bool executeImmediately = true
+			, QPointF const shiftToParent = QPointF());
+
 	virtual void createElement(QMimeData const *mimeData, QPointF const &scenePos
 			, bool searchForParents = true
 			, commands::CreateElementCommand **createCommandPointer = 0


### PR DESCRIPTION
При создании новой ноды (в т.ч. при копировании), она создается стандартных размеров, поэтому при поиске родителя, контейнер надо искать в пределах его изначальных размеров.
Чтоб сделать этот сдвиг к началу контейнера использовал какую-то ненужную штуку, зато теперь больше полезной работы совершается)
