### PR TITLE
CopyPaste: fix edges in container issue

### DIFF
--- a/qrgui/view/copyPaste/clipboardHandler.h
+++ b/qrgui/view/copyPaste/clipboardHandler.h
@@ -30,7 +30,10 @@ private:
 	QList<EdgeElement *> getEdgesForCopying(QList<NodeElement *> const &nodes) const;
 	QList<NodeData> getNodesData(QList<NodeElement *> const &nodes) const;
 	QList<EdgeData> getEdgesData(QList<EdgeElement *> const &edges) const;
+
 	void addChildren(NodeElement *node, QList<NodeElement *> &nodes) const;
+	QSet<EdgeElement *> edgesInContainer(QList<NodeElement *> const &nodes) const;
+	IdList toIdList(QList<NodeElement *> const &nodes) const;
 
 	EditorViewScene *mScene;
 	EditorViewMViface *mMVIface;


### PR DESCRIPTION
тут теперь всё в порядке.

Но что-то  \qrgui\umllib\nodeElement.cpp  стал неправильно сохранять позиции элементов
так при копировании вызываю NodeElement->data() там вижу, что mPos неправильный. 
Т.е. например, ставлю две ноды друг под другом, а там вижу, что их "х" координаты различнаются
