### PR TITLE
static const EPS changed to method.

### DIFF
--- a/qrutils/mathUtils/math.cpp
+++ b/qrutils/mathUtils/math.cpp
@@ -1,5 +1,12 @@
 #include "math.h"
 
+const qreal EPS = 0.00001;
+
+qreal mathUtils::Math::eps()
+{
+	return EPS;
+}
+
 int mathUtils::Math::sign(qreal x)
 {
 	return x > EPS ? 1 : (x < -EPS ? -1 : 0);

--- a/qrutils/mathUtils/math.h
+++ b/qrutils/mathUtils/math.h
@@ -11,7 +11,7 @@ class QRUTILS_EXPORT Math
 {
 public:
 	/// Default precision for all
-	static qreal const QRUTILS_EXPORT EPS = 0.00001;
+	static qreal eps();
 
 	/// Compares given numbers with default precision
 	static bool eq(qreal x, qreal y);


### PR DESCRIPTION
http://stackoverflow.com/questions/370283/why-cant-i-have-a-non-integral-static-const-member-in-a-class
