### PR TITLE
check removed 

### DIFF
--- a/qrkernel/ids.cpp
+++ b/qrkernel/ids.cpp
@@ -23,7 +23,6 @@ Id Id::loadFromString(QString const &string)
 		// Fall-thru
 	}
 	Q_ASSERT(string == result.toString());
-	Q_ASSERT(string == result.toUrl().toString());
 	return result;
 }
 


### PR DESCRIPTION
since Id is never actually cast to QUrl anywhere is the project

and this check is failing, because
symbol '{' is cast to code %7 and result is not identical

this failed check didn't let qreal load projects.
