### PR TITLE
support for <palette sorted="true"> and <palette sorted="false"> in meta...

### DIFF
--- a/plugins/editorsSdk/editorsCommon.pri
+++ b/plugins/editorsSdk/editorsCommon.pri
@@ -1,6 +1,6 @@
 QT += xml widgets
 TEMPLATE =  lib
-CONFIG += plugin
+CONFIG += plugin c++11
 
 isEmpty(ROOT) {
 	error(Please set ROOT variable in a .pro file of your editor as a path to a root folder of QReal sources)

--- a/plugins/robots/editor/generated/robotsMetamodel.xml
+++ b/plugins/robots/editor/generated/robotsMetamodel.xml
@@ -1735,7 +1735,7 @@
 				</logic>
 			</node>
 		</graphicTypes>
-		<palette>
+		<palette sorted="true">
 			<group name="Действия">
 				<element name="Fork"/>
 				<element name="Beep"/>

--- a/qrgui/editorPluginInterface/editorInterface.h
+++ b/qrgui/editorPluginInterface/editorInterface.h
@@ -77,6 +77,7 @@ public:
 	virtual QStringList diagramPaletteGroups(QString const &diagram) const = 0;
 	virtual QStringList diagramPaletteGroupList(QString const &diagram, QString const &group) const = 0;
 	virtual QString diagramPaletteGroupDescription(QString const &diagram, QString const &group) const = 0;
+	virtual bool shallPaletteBeSorted(QString const &diagram) const = 0;
 };
 
 }

--- a/qrgui/mainwindow/palette/paletteTreeWidget.h
+++ b/qrgui/mainwindow/palette/paletteTreeWidget.h
@@ -20,10 +20,11 @@ public:
 			, EditorManagerInterface &editorManagerProxy
 			, bool editable);
 
-	void addGroups(QMap<QString, QList<PaletteElement> > &groups
+	void addGroups(QList<QPair<QString, QList<PaletteElement>>> &groups
 			, QMap<QString, QString> const &descriptions
 			, bool hideIfEmpty
-			, QString const &diagramFriendlyName);
+			, QString const &diagramFriendlyName
+			, bool sort);
 
 	/// Collapses all nodes of all current trees.
 	void collapse();

--- a/qrgui/mainwindow/palette/paletteTreeWidgets.cpp
+++ b/qrgui/mainwindow/palette/paletteTreeWidgets.cpp
@@ -51,27 +51,33 @@ void PaletteTreeWidgets::initWidget(PaletteTreeWidget * const tree)
 void PaletteTreeWidgets::initEditorTree()
 {
 	IdList elements = mEditorManager->elements(mDiagram) + mEditorManager->groups(mDiagram);
-	PaletteTreeWidget::sortByFriendlyName(elements);
+	bool const sort = mEditorManager->shallPaletteBeSorted(mEditor, mDiagram);
+	if (sort) {
+		PaletteTreeWidget::sortByFriendlyName(elements);
+	}
 
 	if (!mEditorManager->paletteGroups(mEditor, mDiagram).empty()) {
-		QMap<QString, QList<PaletteElement> > groups;
+		QList<QPair<QString, QList<PaletteElement>>> groups;
 		QMap<QString, QString> descriptions;
-		foreach (QString const &group, mEditorManager->paletteGroups(mEditor, mDiagram)) {
+		for (QString const &group : mEditorManager->paletteGroups(mEditor, mDiagram)) {
 			QStringList const paletteGroup = mEditorManager->paletteGroupList(mEditor, mDiagram, group);
-			foreach (QString const &name, paletteGroup) {
-				foreach (Id const &element, elements) {
+			QList<PaletteElement> groupElements;
+			for (QString const &name : paletteGroup) {
+				for (Id const &element : elements) {
 					if (element.element() == name) {
-						groups[group] << PaletteElement(*mEditorManager, element);
+						groupElements << PaletteElement(*mEditorManager, element);
 						break;
 					}
 				}
 			}
 
+			groups << qMakePair(group, groupElements);
 			descriptions[group] = mEditorManager->paletteGroupDescription(mEditor, mDiagram, group);
 		}
-		mEditorTree->addGroups(groups, descriptions, false, mEditorManager->friendlyName(mDiagram));
+
+		mEditorTree->addGroups(groups, descriptions, false, mEditorManager->friendlyName(mDiagram), sort);
 	} else {
-		foreach (Id const &element, elements) {
+		for (Id const &element : elements) {
 			addTopItemType(PaletteElement(*mEditorManager, element), mEditorTree);
 		}
 	}

--- a/qrgui/models/details/exploser.cpp
+++ b/qrgui/models/details/exploser.cpp
@@ -38,16 +38,16 @@ void Exploser::refreshAllPalettes()
 
 void Exploser::refreshPalette(gui::PaletteTreeWidget * const tree, Id const &diagram)
 {
-	QMap<QString, QList<gui::PaletteElement> > groups;
+	QList<QPair<QString, QList<gui::PaletteElement>>> groups;
 	QMap<QString, QString> descriptions;
 	descriptions[mUserGroupTitle] = mUserGroupDescription;
 
 	IdList const childTypes = mApi.editorManagerInterface().elements(diagram);
 
-	foreach (Id const &child, childTypes) {
+	for (Id const &child : childTypes) {
 		QList<Explosion> const explosions = mApi.editorManagerInterface().explosions(child);
 
-		foreach (Explosion const &explosion, explosions) {
+		for (Explosion const &explosion : explosions) {
 			if (!explosion.isReusable()) {
 				continue;
 			}
@@ -62,19 +62,24 @@ void Exploser::refreshPalette(gui::PaletteTreeWidget * const tree, Id const &dia
 			}
 
 			IdList const allTargets = mApi.logicalRepoApi().elementsByType(target.element(), true);
-			foreach (Id const &targetInstance, allTargets) {
+			QList<gui::PaletteElement> groupElements;
+			for (Id const &targetInstance : allTargets) {
 				if (mApi.isLogicalId(targetInstance)) {
-					groups[mUserGroupTitle] << gui::PaletteElement(child
+					groupElements << gui::PaletteElement(child
 							, mApi.logicalRepoApi().name(targetInstance)
 							, QString(), mApi.editorManagerInterface().icon(child)
 							, mApi.editorManagerInterface().iconSize(child)
 							, targetInstance);
 				}
 			}
+
+			if (!groupElements.isEmpty()) {
+				groups << qMakePair(mUserGroupTitle, groupElements);
+			}
 		}
 	}
 
-	tree->addGroups(groups, descriptions, true, mApi.editorManagerInterface().friendlyName(diagram));
+	tree->addGroups(groups, descriptions, true, mApi.editorManagerInterface().friendlyName(diagram), true);
 }
 
 void Exploser::customizeExplosionTitles(QString const &userGroupTitle, QString const &userGroupDescription)

--- a/qrgui/pluginManager/editorManager.cpp
+++ b/qrgui/pluginManager/editorManager.cpp
@@ -143,14 +143,20 @@ QString EditorManager::paletteGroupDescription(Id const &editor, const Id &diagr
 	return mPluginIface[editor.editor()]->diagramPaletteGroupDescription(diagram.diagram(), group);
 }
 
+bool EditorManager::shallPaletteBeSorted(Id const &editor, Id const &diagram) const
+{
+	return mPluginIface[editor.editor()]->shallPaletteBeSorted(diagram.diagram());
+}
+
 IdList EditorManager::elements(Id const &diagram) const
 {
 	IdList elements;
 	Q_ASSERT(mPluginsLoaded.contains(diagram.editor()));
 
-	foreach (QString const &e, mPluginIface[diagram.editor()]->elements(diagram.diagram())) {
+	for (QString const &e : mPluginIface[diagram.editor()]->elements(diagram.diagram())) {
 		elements.append(Id(diagram.editor(), diagram.diagram(), e));
 	}
+
 	return elements;
 }
 

--- a/qrgui/pluginManager/editorManager.h
+++ b/qrgui/pluginManager/editorManager.h
@@ -31,85 +31,86 @@ public:
 
 	~EditorManager();
 
-	virtual IdList editors() const;
-	virtual IdList diagrams(Id const &editor) const;
-	virtual IdList groups(Id const &diagram);
-	virtual Pattern getPatternByName (QString const &str) const;
-	virtual QList<QString> getPatternNames() const;
-	virtual QStringList paletteGroups(Id const &editor, Id const &diagram) const;
-	virtual QStringList paletteGroupList(Id const &editor,Id const &diagram, QString const &group) const;
-	virtual QString paletteGroupDescription(Id const &editor, const Id &diagram, const QString &group) const;
-	virtual IdList elements(Id const &diagram) const;
-	virtual bool loadPlugin(QString const &pluginName);
-	virtual bool unloadPlugin(QString const &pluginName);
+	IdList editors() const override;
+	IdList diagrams(Id const &editor) const override;
+	IdList groups(Id const &diagram) override;
+	Pattern getPatternByName (QString const &str) const override;
+	QList<QString> getPatternNames() const override;
+	QStringList paletteGroups(Id const &editor, Id const &diagram) const override;
+	QStringList paletteGroupList(Id const &editor,Id const &diagram, QString const &group) const override;
+	QString paletteGroupDescription(Id const &editor, const Id &diagram, const QString &group) const override;
+	bool shallPaletteBeSorted(Id const &editor, Id const &diagram) const override;
+	IdList elements(Id const &diagram) const override;
+	bool loadPlugin(QString const &pluginName) override;
+	bool unloadPlugin(QString const &pluginName) override;
 
-	virtual QString mouseGesture(Id const &id) const;
-	virtual QString friendlyName(Id const &id) const;
-	virtual QString description(Id const &id) const;
-	virtual QString propertyDescription(Id const &id, QString const &propertyName) const;
-	virtual QString propertyDisplayedName(Id const &id, QString const &propertyName) const;
-	virtual QIcon icon(Id const &id) const;
-	virtual QSize iconSize(Id const &id) const;
-	virtual ElementImpl* elementImpl(Id const &id) const;
+	QString mouseGesture(Id const &id) const override;
+	QString friendlyName(Id const &id) const override;
+	QString description(Id const &id) const override;
+	QString propertyDescription(Id const &id, QString const &propertyName) const override;
+	QString propertyDisplayedName(Id const &id, QString const &propertyName) const override;
+	QIcon icon(Id const &id) const override;
+	QSize iconSize(Id const &id) const override;
+	ElementImpl* elementImpl(Id const &id) const override;
 
-	virtual IdList containedTypes(const Id &id) const;
-	virtual QList<Explosion> explosions(Id const &source) const;
-	virtual QStringList enumValues(Id const &id, const QString &name) const;
-	virtual QString typeName(Id const &id, const QString &name) const;
-	virtual QStringList allChildrenTypesOf(Id const &parent) const;
+	IdList containedTypes(const Id &id) const override;
+	QList<Explosion> explosions(Id const &source) const override;
+	QStringList enumValues(Id const &id, const QString &name) const override;
+	QString typeName(Id const &id, const QString &name) const override;
+	QStringList allChildrenTypesOf(Id const &parent) const override;
 
-	virtual bool isEditor(Id const &id) const;
-	virtual bool isDiagram(Id const &id) const;
-	virtual bool isElement(Id const &id) const;
+	bool isEditor(Id const &id) const override;
+	bool isDiagram(Id const &id) const override;
+	bool isElement(Id const &id) const override;
 
-	virtual QStringList propertyNames(Id const &id) const;
-	virtual QStringList portTypes(Id const &id) const;
-	virtual QStringList referenceProperties(Id const &id) const;
-	virtual QString defaultPropertyValue(Id const &id, QString name) const;
-	virtual QStringList propertiesWithDefaultValues(Id const &id) const;
+	QStringList propertyNames(Id const &id) const override;
+	QStringList portTypes(Id const &id) const override;
+	QStringList referenceProperties(Id const &id) const override;
+	QString defaultPropertyValue(Id const &id, QString name) const override;
+	QStringList propertiesWithDefaultValues(Id const &id) const override;
 
-	virtual IdList checkNeededPlugins(qrRepo::LogicalRepoApi const &logicalApi
-			, qrRepo::GraphicalRepoApi const &graphicalApi) const;
-	virtual bool hasElement(Id const &element) const;
+	IdList checkNeededPlugins(qrRepo::LogicalRepoApi const &logicalApi
+			, qrRepo::GraphicalRepoApi const &graphicalApi) const override;
+	bool hasElement(Id const &element) const override;
 
-	virtual Id findElementByType(QString const &type) const;
-	virtual QList<ListenerInterface *> listeners() const;
+	Id findElementByType(QString const &type) const override;
+	QList<ListenerInterface *> listeners() const override;
 
-	virtual bool isDiagramNode(Id const &id) const;
+	bool isDiagramNode(Id const &id) const override;
 
-	virtual bool isParentOf(Id const &child, Id const &parent) const;
-	virtual bool isGraphicalElementNode(const Id &id) const;
+	bool isParentOf(Id const &child, Id const &parent) const override;
+	bool isGraphicalElementNode(const Id &id) const override;
 
 	/// Returns diagram id if only one diagram loaded or Id() otherwise
-	virtual Id theOnlyDiagram() const;
-	virtual QString diagramNodeNameString(Id const &editor, Id const &diagram) const;
+	Id theOnlyDiagram() const override;
+	QString diagramNodeNameString(Id const &editor, Id const &diagram) const override;
 
-	virtual QList<StringPossibleEdge> possibleEdges(QString const &editor, QString const &element) const;
-	virtual QStringList elements(QString const &editor, QString const &diagram) const;
-	virtual int isNodeOrEdge(QString const &editor, QString const &element) const;
-	virtual bool isParentOf(QString const &editor, QString const &parentDiagram, QString const &parentElement
-			, QString const &childDiagram, QString const &childElement) const;
-	virtual QString diagramName(QString const &editor, QString const &diagram) const;
-	virtual QString diagramNodeName(QString const &editor, QString const &diagram) const;
-	virtual bool isInterpretationMode() const;
-	virtual bool isParentProperty(Id const &id, QString const &propertyName) const;
-	virtual void deleteProperty(QString const &propDisplayedName) const;
-	virtual void addProperty(Id const &id, QString const &propDisplayedName) const;
-	virtual void updateProperties(Id const &id, QString const &property, QString const &propertyType
-			, QString const &propertyDefaultValue, QString const &propertyDisplayedName) const;
-	virtual QString propertyNameByDisplayedName(Id const &id, QString const &displayedPropertyName) const;
-	virtual IdList children(Id const &parent) const;
-	virtual QString shape(Id const &id) const;
-	virtual void updateShape(Id const &id, QString const &graphics) const;
-	virtual void deleteElement(MainWindow *mainWindow, Id const &id) const;
-	virtual bool isRootDiagramNode(Id const &id) const;
-	virtual void addNodeElement(Id const &diagram, QString const &name, bool isRootDiagramNode) const;
-	virtual void addEdgeElement(Id const &diagram, QString const &name, QString const &labelText
+	QList<StringPossibleEdge> possibleEdges(QString const &editor, QString const &element) const override;
+	QStringList elements(QString const &editor, QString const &diagram) const override;
+	int isNodeOrEdge(QString const &editor, QString const &element) const override;
+	bool isParentOf(QString const &editor, QString const &parentDiagram, QString const &parentElement
+			, QString const &childDiagram, QString const &childElement) const override;
+	QString diagramName(QString const &editor, QString const &diagram) const override;
+	QString diagramNodeName(QString const &editor, QString const &diagram) const override;
+	bool isInterpretationMode() const override;
+	bool isParentProperty(Id const &id, QString const &propertyName) const override;
+	void deleteProperty(QString const &propDisplayedName) const override;
+	void addProperty(Id const &id, QString const &propDisplayedName) const override;
+	void updateProperties(Id const &id, QString const &property, QString const &propertyType
+			, QString const &propertyDefaultValue, QString const &propertyDisplayedName) const override;
+	QString propertyNameByDisplayedName(Id const &id, QString const &displayedPropertyName) const override;
+	IdList children(Id const &parent) const override;
+	QString shape(Id const &id) const override;
+	void updateShape(Id const &id, QString const &graphics) const override;
+	void deleteElement(MainWindow *mainWindow, Id const &id) const override;
+	bool isRootDiagramNode(Id const &id) const override;
+	void addNodeElement(Id const &diagram, QString const &name, bool isRootDiagramNode) const override;
+	void addEdgeElement(Id const &diagram, QString const &name, QString const &labelText
 			, QString const &labelType, QString const &lineType, QString const &beginType
-			, QString const &endType) const;
-	virtual QPair<Id, Id> createEditorAndDiagram(QString const &name) const;
-	virtual void saveMetamodel(QString const &newMetamodelFileName);
-	virtual QString saveMetamodelFilePath() const;
+			, QString const &endType) const override;
+	QPair<Id, Id> createEditorAndDiagram(QString const &name) const override;
+	void saveMetamodel(QString const &newMetamodelFileName) override;
+	QString saveMetamodelFilePath() const override;
 
 private:
 	QStringList mPluginsLoaded;

--- a/qrgui/pluginManager/editorManagerInterface.h
+++ b/qrgui/pluginManager/editorManagerInterface.h
@@ -103,6 +103,7 @@ public:
 	virtual QStringList paletteGroups(Id const &editor, Id const &diagram) const = 0;
 	virtual QStringList paletteGroupList(Id const &editor,Id const &diagram, QString const &group) const = 0;
 	virtual QString paletteGroupDescription(Id const &editor, const Id &diagram, const QString &group) const = 0;
+	virtual bool shallPaletteBeSorted(Id const &editor, Id const &diagram) const = 0;
 	virtual QStringList referenceProperties(Id const &id) const = 0;
 	virtual IdList groups(Id const &diagram) = 0;
 	virtual Pattern getPatternByName (QString const &str) const = 0;

--- a/qrgui/pluginManager/interpreterEditorManager.cpp
+++ b/qrgui/pluginManager/interpreterEditorManager.cpp
@@ -992,6 +992,12 @@ QString InterpreterEditorManager::paletteGroupDescription(Id const &editor, cons
 	return "";
 }
 
+bool InterpreterEditorManager::shallPaletteBeSorted(const Id &editor, Id const &diagram) const
+{
+	Q_UNUSED(editor);
+	return true;
+}
+
 IdList InterpreterEditorManager::groups(Id const &diagram)
 {
 	Q_UNUSED(diagram);

--- a/qrgui/pluginManager/interpreterEditorManager.h
+++ b/qrgui/pluginManager/interpreterEditorManager.h
@@ -30,88 +30,96 @@ public:
 	explicit InterpreterEditorManager(QString const &fileName, QObject *parent = NULL);
 	~InterpreterEditorManager();
 
-	virtual IdList editors() const;
-	virtual IdList diagrams(Id const &editor) const;
-	virtual IdList elements(Id const &diagram) const;
-	virtual bool loadPlugin(QString const &pluginName);
-	virtual bool unloadPlugin(QString const &pluginName);
+	IdList editors() const override;
+	IdList diagrams(Id const &editor) const override;
+	IdList elements(Id const &diagram) const override;
+	bool loadPlugin(QString const &pluginName) override;
+	bool unloadPlugin(QString const &pluginName) override;
 
-	virtual QString mouseGesture(Id const &id) const;
-	virtual QString friendlyName(Id const &id) const;
-	virtual QString description(Id const &id) const;
-	virtual QString propertyDescription(Id const &id, QString const &propertyName) const;
-	virtual QString propertyDisplayedName(Id const &id, QString const &propertyName) const;
-	virtual QIcon icon(Id const &id) const;
-	virtual ElementImpl* elementImpl(Id const &id) const;
+	QString mouseGesture(Id const &id) const override;
+	QString friendlyName(Id const &id) const override;
+	QString description(Id const &id) const override;
+	QString propertyDescription(Id const &id, QString const &propertyName) const override;
+	QString propertyDisplayedName(Id const &id, QString const &propertyName) const override;
+	QIcon icon(Id const &id) const override;
+	ElementImpl* elementImpl(Id const &id) const override;
 
-	virtual IdList containedTypes(const Id &id) const;
-	virtual QStringList enumValues(Id const &id, const QString &name) const;
-	virtual QString typeName(Id const &id, const QString &name) const;
-	virtual QStringList allChildrenTypesOf(Id const &parent) const;
+	IdList containedTypes(const Id &id) const override;
+	QStringList enumValues(Id const &id, const QString &name) const override;
+	QString typeName(Id const &id, const QString &name) const override;
+	QStringList allChildrenTypesOf(Id const &parent) const override;
 
-	virtual QList<Explosion> explosions(Id const &source) const;
+	QList<Explosion> explosions(Id const &source) const override;
 
-	virtual bool isEditor(Id const &id) const;
-	virtual bool isDiagram(Id const &id) const;
-	virtual bool isElement(Id const &id) const;
+	bool isEditor(Id const &id) const override;
+	bool isDiagram(Id const &id) const override;
+	bool isElement(Id const &id) const override;
 
-	virtual QStringList propertyNames(Id const &id) const;
-	virtual QStringList portTypes(Id const &id) const;
-	virtual QString defaultPropertyValue(Id const &id, QString name) const;
-	virtual QStringList propertiesWithDefaultValues(Id const &id) const;
+	QStringList propertyNames(Id const &id) const override;
+	QStringList portTypes(Id const &id) const override;
+	QString defaultPropertyValue(Id const &id, QString name) const override;
+	QStringList propertiesWithDefaultValues(Id const &id) const override;
 
-	virtual IdList checkNeededPlugins(qrRepo::LogicalRepoApi const &logicalApi
-			, qrRepo::GraphicalRepoApi const &graphicalApi) const;
-	virtual bool hasElement(Id const &element) const;
+	IdList checkNeededPlugins(qrRepo::LogicalRepoApi const &logicalApi
+			, qrRepo::GraphicalRepoApi const &graphicalApi) const override;
+	bool hasElement(Id const &element) const override;
 
-	virtual Id findElementByType(QString const &type) const;
-	virtual QList<ListenerInterface *> listeners() const;
+	Id findElementByType(QString const &type) const override;
+	QList<ListenerInterface *> listeners() const override;
 
-	virtual bool isDiagramNode(Id const &id) const;
+	bool isDiagramNode(Id const &id) const override;
 
-	virtual bool isParentOf(Id const &child, Id const &parent) const;
-	virtual bool isGraphicalElementNode(const Id &id) const;
+	bool isParentOf(Id const &child, Id const &parent) const override;
+	bool isGraphicalElementNode(const Id &id) const override;
 
 	/// Returns diagram id if only one diagram loaded or Id() otherwise
-	virtual Id theOnlyDiagram() const;
-	virtual QString diagramNodeNameString(Id const &editor, Id const &diagram) const;
+	Id theOnlyDiagram() const override;
+	QString diagramNodeNameString(Id const &editor, Id const &diagram) const override;
 
-	virtual QList<StringPossibleEdge> possibleEdges(QString const &editor, QString const &elementName) const;
-	virtual QStringList elements(QString const &editor, QString const &diagram) const;
-	virtual int isNodeOrEdge(QString const &editor, QString const &element) const;
-	virtual bool isParentOf(QString const &editor, QString const &parentDiagram, QString const &parentElement
-			, QString const &childDiagram, QString const &childElement) const;
-	virtual QString diagramName(QString const &editor, QString const &diagram) const;
-	virtual QString diagramNodeName(QString const &editor, QString const &diagram) const;
-	virtual bool isInterpretationMode() const;
+	QList<StringPossibleEdge> possibleEdges(QString const &editor, QString const &elementName) const override;
+	QStringList elements(QString const &editor, QString const &diagram) const override;
+	int isNodeOrEdge(QString const &editor, QString const &element) const override;
+	bool isParentOf(QString const &editor, QString const &parentDiagram, QString const &parentElement
+			, QString const &childDiagram, QString const &childElement) const override;
+	QString diagramName(QString const &editor, QString const &diagram) const override;
+	QString diagramNodeName(QString const &editor, QString const &diagram) const override;
+	bool isInterpretationMode() const override;
 
-	virtual bool isParentProperty(Id const &id, QString const &propertyName) const;
-	virtual void deletePropertyInElement(qrRepo::RepoApi *repo, Id const &editor, Id const &diagram
-			, QString const &propDisplayedName) const;
-	virtual void deleteProperty(QString const &propDisplayedName) const;
-	virtual void addProperty(Id const &id, QString const &propDisplayedName) const;
-	virtual void updateProperties(Id const &id, QString const &property, QString const &propertyType
-			, QString const &propertyDefaultValue, QString const &propertyDisplayedName) const;
-	virtual QString propertyNameByDisplayedName(Id const &id, QString const &displayedPropertyName) const;
-	virtual IdList children(Id const &parent) const;
-	virtual QString shape(Id const &id) const;
-	virtual void updateShape(Id const &id, QString const &graphics) const;
-	virtual void deleteElement(qReal::MainWindow *mainWindow, Id const &id) const;
-	virtual bool isRootDiagramNode(Id const &id) const;
-	virtual void addNodeElement(Id const &diagram, QString const &name, bool isRootDiagramNode) const;
-	virtual void addEdgeElement(Id const &diagram, QString const &name, QString const &labelText
-			, QString const &labelType, QString const &lineType, QString const &beginType, QString const &endType) const;
-	virtual QPair<Id, Id> createEditorAndDiagram(QString const &name) const;
-	virtual void saveMetamodel(QString const &newMetamodelFileName);
-	virtual QString saveMetamodelFilePath() const;
-	virtual QStringList paletteGroups(Id const &editor, Id const &diagram) const;
-	virtual QStringList paletteGroupList(Id const &editor,Id const &diagram, QString const &group) const;
-	virtual QString paletteGroupDescription(Id const &editor, const Id &diagram, const QString &group) const;
-	virtual QStringList referenceProperties(Id const &id) const;
-	virtual IdList groups(Id const &diagram);
-	virtual Pattern getPatternByName (QString const &str) const;
-	virtual QList<QString> getPatternNames() const;
-	virtual QSize iconSize(Id const &id) const;
+	bool isParentProperty(Id const &id, QString const &propertyName) const override;
+	void deleteProperty(QString const &propDisplayedName) const override;
+	void addProperty(Id const &id, QString const &propDisplayedName) const override;
+	void updateProperties(Id const &id, QString const &property, QString const &propertyType
+			, QString const &propertyDefaultValue, QString const &propertyDisplayedName) const override;
+	QString propertyNameByDisplayedName(Id const &id, QString const &displayedPropertyName) const override;
+	IdList children(Id const &parent) const override;
+	QString shape(Id const &id) const override;
+	void updateShape(Id const &id, QString const &graphics) const override;
+	void deleteElement(qReal::MainWindow *mainWindow, Id const &id) const override;
+	bool isRootDiagramNode(Id const &id) const override;
+	void addNodeElement(Id const &diagram, QString const &name, bool isRootDiagramNode) const override;
+
+	void addEdgeElement(
+			Id const &diagram
+			, QString const &name
+			, QString const &labelText
+			, QString const &labelType
+			, QString const &lineType
+			, QString const &beginType
+			, QString const &endType
+			) const override;
+
+	QPair<Id, Id> createEditorAndDiagram(QString const &name) const override;
+	void saveMetamodel(QString const &newMetamodelFileName) override;
+	QString saveMetamodelFilePath() const override;
+	QStringList paletteGroups(Id const &editor, Id const &diagram) const override;
+	QStringList paletteGroupList(Id const &editor,Id const &diagram, QString const &group) const override;
+	QString paletteGroupDescription(Id const &editor, const Id &diagram, const QString &group) const override;
+	bool shallPaletteBeSorted(Id const &editor, Id const &diagram) const override;
+	QStringList referenceProperties(Id const &id) const override;
+	IdList groups(Id const &diagram) override;
+	Pattern getPatternByName (QString const &str) const override;
+	QList<QString> getPatternNames() const override;
+	QSize iconSize(Id const &id) const override;
 
 private:
 	class CheckPropertyForParent;
@@ -133,6 +141,8 @@ private:
 	QStringList propertiesFromParents(Id const &id, QString const &propertyName
 			, CheckPropertyForParent const &checker) const;
 	QString valueOfProperty(Id const &id, QString const &propertyName, QString const &value) const;
+	void deletePropertyInElement(qrRepo::RepoApi *repo, Id const &editor, Id const &diagram
+			, QString const &propDisplayedName) const;
 };
 
 }

--- a/qrgui/pluginManager/proxyEditorManager.cpp
+++ b/qrgui/pluginManager/proxyEditorManager.cpp
@@ -312,7 +312,12 @@ QString ProxyEditorManager::paletteGroupDescription(Id const &editor, const Id &
 	return mProxiedEditorManager->paletteGroupDescription(editor, diagram, group);
 }
 
-QStringList ProxyEditorManager::referenceProperties(const Id &id) const
+bool ProxyEditorManager::shallPaletteBeSorted(Id const &editor, Id const &diagram) const
+{
+	return mProxiedEditorManager->shallPaletteBeSorted(editor, diagram);
+}
+
+QStringList ProxyEditorManager::referenceProperties(Id const &id) const
 {
 	return mProxiedEditorManager->referenceProperties(id);
 }

--- a/qrgui/pluginManager/proxyEditorManager.h
+++ b/qrgui/pluginManager/proxyEditorManager.h
@@ -26,90 +26,92 @@ class ProxyEditorManager : public EditorManagerInterface
 public:
 	ProxyEditorManager(EditorManagerInterface *editorManagerInterface);
 	~ProxyEditorManager();
-	IdList editors() const;
-	IdList diagrams(Id const &editor) const;
-	IdList elements(Id const &diagram) const;
-	bool loadPlugin(QString const &pluginName);
-	bool unloadPlugin(QString const &pluginName);
 
-	QString mouseGesture(Id const &id) const;
-	QString friendlyName(Id const &id) const;
-	QString description(Id const &id) const;
-	QString propertyDescription(Id const &id, QString const &propertyName) const;
-	QString propertyDisplayedName(Id const &id, QString const &propertyName) const;
-	QIcon icon(Id const &id) const;
-	ElementImpl* elementImpl(Id const &id) const;
+	IdList editors() const override;
+	IdList diagrams(Id const &editor) const override;
+	IdList elements(Id const &diagram) const override;
+	bool loadPlugin(QString const &pluginName) override;
+	bool unloadPlugin(QString const &pluginName) override;
 
-	IdList containedTypes(const Id &id) const;
-	IdList usedTypes(const Id &id) const;
-	QStringList enumValues(Id const &id, const QString &name) const;
-	QString typeName(Id const &id, const QString &name) const;
-	QStringList allChildrenTypesOf(Id const &parent) const;
+	QString mouseGesture(Id const &id) const override;
+	QString friendlyName(Id const &id) const override;
+	QString description(Id const &id) const override;
+	QString propertyDescription(Id const &id, QString const &propertyName) const override;
+	QString propertyDisplayedName(Id const &id, QString const &propertyName) const override;
+	QIcon icon(Id const &id) const override;
+	ElementImpl* elementImpl(Id const &id) const override;
 
-	QList<Explosion> explosions(Id const &source) const;
+	IdList containedTypes(const Id &id) const override;
+	QStringList enumValues(Id const &id, const QString &name) const override;
+	QString typeName(Id const &id, const QString &name) const override;
+	QStringList allChildrenTypesOf(Id const &parent) const override;
 
-	bool isEditor(Id const &id) const;
-	bool isDiagram(Id const &id) const;
-	bool isElement(Id const &id) const;
+	QList<Explosion> explosions(Id const &source) const override;
 
-	QStringList propertyNames(Id const &id) const;
-	QStringList portTypes(Id const &id) const;
-	QString defaultPropertyValue(Id const &id, QString name) const;
-	QStringList propertiesWithDefaultValues(Id const &id) const;
+	bool isEditor(Id const &id) const override;
+	bool isDiagram(Id const &id) const override;
+	bool isElement(Id const &id) const override;
+
+	QStringList propertyNames(Id const &id) const override;
+	QStringList portTypes(Id const &id) const override;
+	QString defaultPropertyValue(Id const &id, QString name) const override;
+	QStringList propertiesWithDefaultValues(Id const &id) const override;
 
 	IdList checkNeededPlugins(qrRepo::LogicalRepoApi const &logicalApi
-			, qrRepo::GraphicalRepoApi const &graphicalApi) const;
-	bool hasElement(Id const &element) const;
+			, qrRepo::GraphicalRepoApi const &graphicalApi) const override;
+	bool hasElement(Id const &element) const override;
 
-	Id findElementByType(QString const &type) const;
-	QList<ListenerInterface *> listeners() const;
+	Id findElementByType(QString const &type) const override;
+	QList<ListenerInterface *> listeners() const override;
 
-	bool isDiagramNode(Id const &id) const;
+	bool isDiagramNode(Id const &id) const override;
 
-	bool isParentOf(Id const &child, Id const &parent) const;
-	bool isGraphicalElementNode(const Id &id) const;
+	bool isParentOf(Id const &child, Id const &parent) const override;
+	bool isGraphicalElementNode(const Id &id) const override;
 
 	/// Returns diagram id if only one diagram loaded or Id() otherwise
-	Id theOnlyDiagram() const;
-	QString diagramNodeNameString(Id const &editor, Id const &diagram) const;
+	Id theOnlyDiagram() const override;
+	QString diagramNodeNameString(Id const &editor, Id const &diagram) const override;
 
-	QList<StringPossibleEdge> possibleEdges(QString const &editor, QString const &element) const;
-	QStringList elements(QString const &editor, QString const &diagram) const;
-	int isNodeOrEdge(QString const &editor, QString const &element) const;
+	QList<StringPossibleEdge> possibleEdges(QString const &editor, QString const &element) const override;
+	QStringList elements(QString const &editor, QString const &diagram) const override;
+	int isNodeOrEdge(QString const &editor, QString const &element) const override;
 	bool isParentOf(QString const &editor, QString const &parentDiagram, QString const &parentElement
-			, QString const &childDiagram, QString const &childElement) const;
-	QString diagramName(QString const &editor, QString const &diagram) const;
-	QString diagramNodeName(QString const &editor, QString const &diagram) const;
+			, QString const &childDiagram, QString const &childElement) const override;
+	QString diagramName(QString const &editor, QString const &diagram) const override;
+	QString diagramNodeName(QString const &editor, QString const &diagram) const override;
 
 	// Takes ownership.
 	void setProxyManager(EditorManagerInterface *editorManagerInterface);
-	bool isInterpretationMode() const;
-	bool isParentProperty(Id const &id, QString const &propertyName) const;
-	void deleteProperty(QString const &propDisplayedName) const;
-	void addProperty(Id const &id, QString const &propDisplayedName) const;
-	void updateProperties(Id const &id, QString const &property, QString const &propertyType
-			, QString const &propertyDefaultValue, QString const &propertyDisplayedName) const;
-	QString propertyNameByDisplayedName(Id const &id, QString const &displayedPropertyName) const;
-	IdList children(Id const &parent) const;
-	QString shape(Id const &id) const;
-	void updateShape(Id const &id, QString const &graphics) const;
-	void deleteElement(MainWindow *mainWindow, Id const &id) const;
-	bool isRootDiagramNode(Id const &id) const;
-	void addNodeElement(Id const &diagram, QString const &name, bool isRootDiagramNode) const;
-	void addEdgeElement(Id const &diagram, QString const &name, QString const &labelText, QString const &labelType
-			, QString const &lineType, QString const &beginType, QString const &endType) const;
-	QPair<Id, Id> createEditorAndDiagram(QString const &name) const;
-	void saveMetamodel(QString const &newMetamodelFileName);
-	QString saveMetamodelFilePath() const;
 
-	QStringList paletteGroups(Id const &editor, Id const &diagram) const;
-	QStringList paletteGroupList(Id const &editor,Id const &diagram, QString const &group) const;
-	QString paletteGroupDescription(Id const &editor, const Id &diagram, const QString &group) const;
-	virtual QStringList referenceProperties(Id const &id) const;
-	IdList groups(Id const &diagram);
-	Pattern getPatternByName (QString const &str) const;
-	QList<QString> getPatternNames() const;
-	QSize iconSize(Id const &id) const;
+	bool isInterpretationMode() const override;
+	bool isParentProperty(Id const &id, QString const &propertyName) const override;
+	void deleteProperty(QString const &propDisplayedName) const override;
+	void addProperty(Id const &id, QString const &propDisplayedName) const override;
+	void updateProperties(Id const &id, QString const &property, QString const &propertyType
+			, QString const &propertyDefaultValue, QString const &propertyDisplayedName) const override;
+	QString propertyNameByDisplayedName(Id const &id, QString const &displayedPropertyName) const override;
+	IdList children(Id const &parent) const override;
+	QString shape(Id const &id) const override;
+	void updateShape(Id const &id, QString const &graphics) const override;
+	void deleteElement(MainWindow *mainWindow, Id const &id) const override;
+	bool isRootDiagramNode(Id const &id) const override;
+	void addNodeElement(Id const &diagram, QString const &name, bool isRootDiagramNode) const override;
+	void addEdgeElement(Id const &diagram, QString const &name, QString const &labelText, QString const &labelType
+			, QString const &lineType, QString const &beginType, QString const &endType) const override;
+	QPair<Id, Id> createEditorAndDiagram(QString const &name) const override;
+	void saveMetamodel(QString const &newMetamodelFileName) override;
+	QString saveMetamodelFilePath() const override;
+
+	QStringList paletteGroups(Id const &editor, Id const &diagram) const override;
+	QStringList paletteGroupList(Id const &editor,Id const &diagram, QString const &group) const override;
+	QString paletteGroupDescription(Id const &editor, const Id &diagram, const QString &group) const override;
+	bool shallPaletteBeSorted(Id const &editor, Id const &diagram) const override;
+	virtual QStringList referenceProperties(Id const &id) const override;
+	IdList groups(Id const &diagram) override;
+	Pattern getPatternByName (QString const &str) const override;
+	QList<QString> getPatternNames() const override;
+	QSize iconSize(Id const &id) const override;
 
 private:
 	EditorManagerInterface *mProxiedEditorManager;  // Has ownership.

--- a/qrxc/diagram.h
+++ b/qrxc/diagram.h
@@ -22,8 +22,9 @@ public:
 	QString nodeName() const;
 	QString displayedName() const;
 	QString getGroupsXML() const;
-	QMap<QString, QStringList> paletteGroups() const;
+	QList<QPair<QString, QStringList>> paletteGroups() const;
 	QMap<QString, QString> paletteGroupsDescriptions() const;
+	bool shallPaletteBeSorted() const;
 
 private:
 	struct ImportSpecification {
@@ -38,11 +39,12 @@ private:
 	QString mDiagramDisplayedName;
 	Editor *mEditor;
 	QString mGroupsXML;
-	QMap<QString, QStringList> mPaletteGroups;
+	QList<QPair<QString, QStringList>> mPaletteGroups;
 	QMap<QString, QString> mPaletteGroupsDescriptions;
 	QList<ImportSpecification> mImports;
+	bool mShallPaletteBeSorted;
 
 	bool initGraphicTypes(QDomElement const &graphicTypesElement);
 	bool initNonGraphicTypes(QDomElement const &nonGraphicTypesElement);
-	void initPaletteGroups(QDomElement const &paletteGroupsElement);
+	void initPalette(QDomElement const &paletteElement);
 };

--- a/qrxc/xmlCompiler.cpp
+++ b/qrxc/xmlCompiler.cpp
@@ -155,7 +155,7 @@ void XmlCompiler::generatePluginHeader()
 		<< "#include <QtCore/QStringList>\n"
 		<< "#include <QtCore/QMap>\n"
 		<< "#include <QtGui/QIcon>\n"
-		<< "#include <QPair>"
+		<< "#include <QtCore/QPair>"
 		<< "\n"
 		<< "#include \"../" << mSourcesRootFolder << "/qrgui/editorPluginInterface/editorInterface.h\"\n"
 		<< "\n"
@@ -167,6 +167,54 @@ void XmlCompiler::generatePluginHeader()
 		<< "\n"
 		<< "\t" << mPluginName << "Plugin();\n"
 		<< "\n"
+		<< "\tQString id() const { return \"" << mPluginName << "\"; }\n"
+		<< "\n"
+		<< "\tQStringList diagrams() const override;\n"
+		<< "\tQStringList elements(QString const &diagram) const override;\n"
+		<< "\tQStringList getPropertiesWithDefaultValues(QString const &element) const override;\n"
+		<< "\n"
+		<< "\tQStringList getTypesContainedBy(QString const &element) const override;\n"
+		<< "\tQList<QPair<QPair<QString, QString>, QPair<bool, QString>>> getPossibleEdges(QString "
+				"const &element) const override;\n"
+		<< "\tQList<qReal::EditorInterface::ExplosionData> explosions(QString const &diagram, QString "
+				"const &element) const override;\n"
+		<< "\n"
+		<< "\tint isNodeOrEdge(QString const &element) const override;\n"
+		<< "\n"
+		<< "\tQIcon getIcon(qReal::SdfIconEngineV2Interface *engine) const override;\n"
+		<< "\tqReal::ElementImpl* getGraphicalObject(QString const &diagram, QString const &element) const override;\n"
+		<< "\tQString getPropertyType(QString const &element, QString const &property) const override;\n"
+		<< "\tQString getPropertyDefaultValue(QString const &element, QString const &property) const override;\n"
+		<< "\tQStringList getPropertyNames(QString const &diagram, QString const &element) const override;\n"
+		<< "\tQStringList getPortTypes(QString const &diagram, QString const &element) const override;\n"
+		<< "\tQStringList getReferenceProperties(QString const &diagram, QString const &element) const override;\n"
+		<< "\tQStringList getEnumValues(QString name) const override;\n"
+		<< "\tQString getGroupsXML() const override;\n"
+		<< "\tQList<QPair<QString, QString>> getParentsOf(QString const &diagram, QString const &element) "
+				"const override;\n"
+		<< "\n"
+		<< "\tQString editorName() const override;\n"
+		<< "\tQString diagramName(QString const &diagram) const override;\n"
+		<< "\tQString diagramNodeName(QString const &diagram) const override;\n"
+		<< "\tQString elementName(QString const &diagram, QString const &element) const override;\n"
+		<< "\tQString elementDescription(QString const &diagram, QString const &element) const override;\n"
+		<< "\tQString propertyDescription(QString const &diagram, QString const &element, QString const "
+				"&property) const override;\n"
+		<< "\tQString propertyDisplayedName(QString const &diagram, QString const &element, QString const "
+				"&property) const override;\n"
+		<< "\tQString elementMouseGesture(QString const &digram, QString const &element) const override;\n"
+		<< "\n"
+		<< "\tQList<qReal::ListenerInterface*> listeners() const override;\n"
+		<< "\n"
+		<< "\tbool isParentOf(QString const &parentDiagram, QString const &parentElement, QString const "
+				"&childDiagram, QString const &childElement) const override;\n"
+		<< "\n"
+		<< "\tQStringList diagramPaletteGroups(QString const &diagram) const override;\n"
+		<< "\tQStringList diagramPaletteGroupList(QString const &diagram, QString const &group) const override;\n"
+		<< "\tQString diagramPaletteGroupDescription(QString const &diagram, QString const &group) const override;\n"
+		<< "\tbool shallPaletteBeSorted(QString const &diagram) const override;\n"
+		<< "\n"
+		<< "private:\n"
 		<< "\tvirtual void initPlugin();\n"
 		<< "\tvirtual void initMouseGestureMap();\n"
 		<< "\tvirtual void initNameMap();\n"
@@ -176,71 +224,26 @@ void XmlCompiler::generatePluginHeader()
 		<< "\tvirtual void initParentsMap();\n"
 		<< "\tvirtual void initPaletteGroupsMap();\n"
 		<< "\tvirtual void initPaletteGroupsDescriptionMap();\n"
+		<< "\tvirtual void initShallPaletteBeSortedMap();\n"
 		<< "\tvirtual void initExplosionsMap();\n"
 		<< "\n"
-		<< "\tvirtual QString id() const { return \"" << mPluginName << "\"; }\n"
-		<< "\n"
-		<< "\tvirtual QStringList diagrams() const;\n"
-		<< "\tvirtual QStringList elements(QString const &diagram) const;\n"
-		<< "\tvirtual QStringList getPropertiesWithDefaultValues(QString const &element) const;\n"
-		<< "\n"
-		<< "\tvirtual QStringList getTypesContainedBy(QString const &element) const;\n"
-		<< "\tvirtual QList<QPair<QPair<QString,QString>,QPair<bool,QString> > > getPossibleEdges(QString "
-				"const &element) const;\n"
-		<< "\tvirtual QList<qReal::EditorInterface::ExplosionData> explosions(QString const &diagram, QString "
-				"const &element) const;\n"
-		<< "\n"
-		<< "\tvirtual int isNodeOrEdge(QString const &element) const; \n"
-		<< "\n"
-		<< "\tvirtual QIcon getIcon(qReal::SdfIconEngineV2Interface *engine) const;\n"
-		<< "\tvirtual qReal::ElementImpl* getGraphicalObject(QString const &diagram, QString const &element) const;\n"
-		<< "\tvirtual QString getPropertyType(QString const &element, QString const &property) const;\n"
-		<< "\tvirtual QString getPropertyDefaultValue(QString const &element, QString const &property) const;\n"
-		<< "\tvirtual QStringList getPropertyNames(QString const &diagram, QString const &element) const;\n"
-		<< "\tvirtual QStringList getPortTypes(QString const &diagram, QString const &element) const;\n"
-		<< "\tvirtual QStringList getReferenceProperties(QString const &diagram, QString const &element) const;\n"
-		<< "\tvirtual QStringList getEnumValues(QString name) const;\n"
-		<< "\tvirtual QString getGroupsXML() const;\n"
-		<< "\tvirtual QList<QPair<QString, QString> > getParentsOf(QString const &diagram, QString const &element) "
-				"const;\n"
-		<< "\n"
-		<< "\tvirtual QString editorName() const;\n"
-		<< "\tvirtual QString diagramName(QString const &diagram) const;\n"
-		<< "\tvirtual QString diagramNodeName(QString const &diagram) const;\n"
-		<< "\tvirtual QString elementName(QString const &diagram, QString const &element) const;\n"
-		<< "\tvirtual QString elementDescription(QString const &diagram, QString const &element) const;\n"
-		<< "\tvirtual QString propertyDescription(QString const &diagram, QString const &element, QString const "
-				"&property) const;\n"
-		<< "\tvirtual QString propertyDisplayedName(QString const &diagram, QString const &element, QString const "
-				"&property) const;\n"
-		<< "\tvirtual QString elementMouseGesture(QString const &digram, QString const &element) const;\n"
-		<< "\n"
-		<< "\tvirtual QList<qReal::ListenerInterface*> listeners() const;\n"
-		<< "\n"
-		<< "\tvirtual bool isParentOf(QString const &parentDiagram, QString const &parentElement, QString const "
-				"&childDiagram, QString const &childElement) const;\n"
-		<< "\n"
-		<< "\tvirtual QStringList diagramPaletteGroups(QString const &diagram) const;\n"
-		<< "\tvirtual QStringList diagramPaletteGroupList(QString const &diagram, QString const &group) const;\n"
-		<< "\tvirtual QString diagramPaletteGroupDescription(QString const &diagram, QString const &group) const;\n"
-		<< "\n"
-		<< "private:\n"
 		<< "\tQMap<QString, QIcon> mIconMap;\n"
 		<< "\tQMap<QString, QString> mDiagramNameMap;\n"
 		<< "\tQMap<QString, QString> mDiagramNodeNameMap;\n"
-		<< "\tQMap<QString, QMap<QString, QString> > mPropertyTypes;\n"
-		<< "\tQMap<QString, QMap<QString, QString> > mPropertyDefault;\n"
-		<< "\tQMap<QString, QMap<QString, QString> > mElementsNameMap;\n"
-		<< "\tQMap<QString, QMap<QString, QString> > mElementsDescriptionMap;\n"
-		<< "\tQMap<QString, QMap<QString, QMap<QString, QString> > > mPropertiesDescriptionMap;\n"
-		<< "\tQMap<QString, QMap<QString, QMap<QString, QString> > > mPropertiesDisplayedNamesMap;\n"
-		<< "\tQMap<QString, QMap<QString, QString> > mElementMouseGesturesMap;\n"
-		<< "\tQMap<QString, QMap<QString, QList<QPair<QString, QString> > > > mParentsMap;  // Maps diagram and element"
+		<< "\tQMap<QString, QMap<QString, QString>> mPropertyTypes;\n"
+		<< "\tQMap<QString, QMap<QString, QString>> mPropertyDefault;\n"
+		<< "\tQMap<QString, QMap<QString, QString>> mElementsNameMap;\n"
+		<< "\tQMap<QString, QMap<QString, QString>> mElementsDescriptionMap;\n"
+		<< "\tQMap<QString, QMap<QString, QMap<QString, QString>>> mPropertiesDescriptionMap;\n"
+		<< "\tQMap<QString, QMap<QString, QMap<QString, QString>>> mPropertiesDisplayedNamesMap;\n"
+		<< "\tQMap<QString, QMap<QString, QString>> mElementMouseGesturesMap;\n"
+		<< "\tQMap<QString, QMap<QString, QList<QPair<QString, QString>>>> mParentsMap;  // Maps diagram and element"
 				" to a list of diagram-element pairs of parents (generalization relation).\n"
-		<< "\tQMap<QString, QMap<QString, QStringList > > mPaletteGroupsMap;  // Maps element`s lists of all "
+		<< "\tQMap<QString, QList<QPair<QString, QStringList>>> mPaletteGroupsMap;  // Maps element`s lists of all "
 				"palette groups.\n"
-		<< "\tQMap<QString, QMap<QString, QString > > mPaletteGroupsDescriptionMap; \n"
-		<< "\tQMap<QString, QMap<QString, QList<qReal::EditorInterface::ExplosionData> > > mExplosionsMap;\n"
+		<< "\tQMap<QString, QMap<QString, QString>> mPaletteGroupsDescriptionMap;\n"
+		<< "\tQMap<QString, bool> mShallPaletteBeSortedMap;\n"
+		<< "\tQMap<QString, QMap<QString, QList<qReal::EditorInterface::ExplosionData>>> mExplosionsMap;\n"
 		<< "};\n"
 		<< "\n";
 }
@@ -300,6 +303,7 @@ void XmlCompiler::generateInitPlugin(OutFile &out)
 		<< "\tinitParentsMap();\n"
 		<< "\tinitPaletteGroupsMap();\n"
 		<< "\tinitPaletteGroupsDescriptionMap();\n"
+		<< "\tinitShallPaletteBeSortedMap();\n"
 		<< "\tinitExplosionsMap();\n"
 		<< "}\n\n";
 
@@ -311,6 +315,7 @@ void XmlCompiler::generateInitPlugin(OutFile &out)
 	generatePropertyDefaultsMap(out);
 	generateDescriptionMappings(out);
 	generateParentsMappings(out);
+	generateShallPaletteBeSorted(out);
 	generateExplosionsMappings(out);
 }
 
@@ -348,17 +353,24 @@ void XmlCompiler::generatePaletteGroupsLists(utils::OutFile &out)
 {
 	out() << "void " << mPluginName << "Plugin::initPaletteGroupsMap()\n{\n";
 
-	foreach (Diagram *diagram, mEditors[mCurrentEditor]->diagrams().values()) {
+	for (Diagram *diagram : mEditors[mCurrentEditor]->diagrams().values()) {
 		QString diagramName = NameNormalizer::normalize(diagram->name());
-		QMap<QString, QStringList > paletteGroups = diagram->paletteGroups();
-		foreach (QList<QString> list , paletteGroups) {
-			QString groupName = paletteGroups.key(list);
-			foreach (QString name, list) {
-				out() << "\tmPaletteGroupsMap[QString::fromUtf8(\""
-					<< diagramName << "\")][QString::fromUtf8(\""
-					<< groupName << "\")].append(QString::fromUtf8(\""
-					<< NameNormalizer::normalize(name) << "\"));\n";
+		QList<QPair<QString, QStringList>> paletteGroups = diagram->paletteGroups();
+		for (QPair<QString, QStringList> const &group: paletteGroups) {
+			QString const groupName = group.first;
+
+			out() << "\t{\n";
+			out() << "\t\tQStringList groupElements;\n";
+
+			for (QString const &name : group.second) {
+				out() << "\t\tgroupElements << QString::fromUtf8(\"" << NameNormalizer::normalize(name) << "\");\n";
 			}
+
+			out() << "\t\tmPaletteGroupsMap[QString::fromUtf8(\""
+				<< diagramName << "\")].append(qMakePair(QString::fromUtf8(\""
+				<< groupName << "\"), groupElements));\n";
+
+			out() << "\t}\n";
 		}
 	}
 	out() << "}\n\n";
@@ -370,9 +382,9 @@ void XmlCompiler::generatePaletteGroupsDescriptions(utils::OutFile &out)
 
 	foreach (Diagram *diagram, mEditors[mCurrentEditor]->diagrams().values()) {
 		QString diagramName = NameNormalizer::normalize(diagram->name());
-		QMap<QString, QString > paletteGroupsDescriptions = diagram->paletteGroupsDescriptions();
-		foreach (QString groupName, paletteGroupsDescriptions.keys()) {
-			QString descriptionName = paletteGroupsDescriptions[groupName];
+		QMap<QString, QString> paletteGroupsDescriptions = diagram->paletteGroupsDescriptions();
+		foreach (QString const &groupName, paletteGroupsDescriptions.keys()) {
+			QString const descriptionName = paletteGroupsDescriptions[groupName];
 			if (!descriptionName.isEmpty()) {
 				out() << "\tmPaletteGroupsDescriptionMap[QString::fromUtf8(\""
 					<< diagramName << "\")][QString::fromUtf8(\""
@@ -380,6 +392,18 @@ void XmlCompiler::generatePaletteGroupsDescriptions(utils::OutFile &out)
 					<< descriptionName << "\");\n";
 			}
 		}
+	}
+	out() << "}\n\n";
+}
+
+void XmlCompiler::generateShallPaletteBeSorted(utils::OutFile &out)
+{
+	out() << "void " << mPluginName << "Plugin::initShallPaletteBeSortedMap()\n{\n";
+
+	for (Diagram const * const diagram : mEditors[mCurrentEditor]->diagrams().values()) {
+		QString const diagramName = NameNormalizer::normalize(diagram->name());
+		out() << "\tmShallPaletteBeSortedMap[QString::fromUtf8(\""
+			<< diagramName << "\")] = " << (diagram->shallPaletteBeSorted() ? "true" : "false") << ";\n";
 	}
 	out() << "}\n\n";
 }
@@ -490,17 +514,33 @@ void XmlCompiler::generateNameMappingsRequests(OutFile &out)
 		<< "}\n\n"
 
 		<< "QStringList " << mPluginName << "Plugin::diagramPaletteGroups(QString const &diagram) const\n{\n"
-		<< "\treturn mPaletteGroupsMap[diagram].keys();\n"
+
+		<< "\tQStringList result;\n"
+		<< "\tfor (QPair<QString, QStringList> const &group : mPaletteGroupsMap[diagram]) {\n"
+		<< "\t\tresult << group.first;\n"
+		<< "\t}\n"
+		<< "\n"
+		<< "\treturn result;\n"
 		<< "}\n\n"
 
 		<< "QStringList " << mPluginName << "Plugin::diagramPaletteGroupList(QString const &diagram, "
 		<< "QString const &group) const\n{\n"
-		<< "\treturn mPaletteGroupsMap[diagram][group];\n"
+		<< "\tfor (QPair<QString, QStringList> const &ourGroup : mPaletteGroupsMap[diagram]) {\n"
+		<< "\t\tif (ourGroup.first == group) {\n"
+		<< "\t\t\treturn ourGroup.second;\n"
+		<< "\t\t}\n"
+		<< "\t}\n"
+		<< "\n"
+		<< "\treturn QStringList();\n"
 		<< "}\n\n"
 
 		<< "QString " << mPluginName << "Plugin::diagramPaletteGroupDescription(QString const &diagram, "
 		<< "QString const &group) const\n{\n"
 		<< "\treturn mPaletteGroupsDescriptionMap[diagram][group];\n"
+		<< "}\n\n"
+
+		<< "bool " << mPluginName << "Plugin::shallPaletteBeSorted(QString const &diagram) const\n{\n"
+		<< "\treturn mShallPaletteBeSortedMap[diagram];\n"
 		<< "}\n\n"
 
 		<< "QStringList " << mPluginName << "Plugin::elements(QString const &diagram) const\n{\n"

--- a/qrxc/xmlCompiler.h
+++ b/qrxc/xmlCompiler.h
@@ -52,6 +52,7 @@ private:
 	void generatePropertyDefaultsRequests(utils::OutFile &out);
 	void generatePaletteGroupsLists(utils::OutFile &out);
 	void generatePaletteGroupsDescriptions(utils::OutFile &out);
+	void generateShallPaletteBeSorted(utils::OutFile &out);
 
 	class ListMethodGenerator;
 	class PropertiesGenerator;


### PR DESCRIPTION
...model, which specifies whether to sort elements in a group and groups themselves by name or leave them in order specified by metamodel. Needed for TRIKStudio, where Smile and SadSmile blocks shall be adjacent. It also allows to fix some usability issues related to commonly used blocks are too hard to find in a palette.
