### PR TITLE
2D model fixes for geek picnic

### DIFF
--- a/plugins/robots/robotsInterpreter/details/d2RobotModel/sensorItem.cpp
+++ b/plugins/robots/robotsInterpreter/details/d2RobotModel/sensorItem.cpp
@@ -7,7 +7,7 @@ using namespace qReal::interpreters::robots;
 using namespace details::d2Model;
 using namespace graphicsUtils;
 
-int const selectionDrift = 3;
+int const selectionDrift = 7;
 
 SensorItem::SensorItem(SensorsConfiguration &configuration
 		, robots::enums::inputPort::InputPortEnum port)
@@ -16,7 +16,7 @@ SensorItem::SensorItem(SensorsConfiguration &configuration
 	, mPort(port)
 	, mDragged(false)
 	, mPointImpl()
-	, mRotater(NULL)
+	, mRotater(nullptr)
 	, mImageRect(imageRect())
 	, mBoundingRect(mImageRect.adjusted(-selectionDrift, -selectionDrift
 			, selectionDrift, selectionDrift))

--- a/plugins/robots/robotsInterpreter/details/interpreter.cpp
+++ b/plugins/robots/robotsInterpreter/details/interpreter.cpp
@@ -145,7 +145,6 @@ void Interpreter::onTabChanged(Id const &diagramId, bool enabled)
 		loadSensorConfiguration(logicalId);
 		enableD2ModelWidgetRunStopButtons();
 	} else {
-		mD2ModelWidget->loadXml(QDomDocument());
 		disableD2ModelWidgetRunStopButtons();
 	}
 }


### PR DESCRIPTION
Increased sensor region for more convenient touch dragging
Disabled 2D model reinitialization when active tab changes to non-diagram one
