### PR TITLE
setting default value for association 

### DIFF
--- a/plugins/metaEditor/editor/metaEditor.xml
+++ b/plugins/metaEditor/editor/metaEditor.xml
@@ -434,8 +434,12 @@
 				<logic>
 					<generalizations/>
 					<properties>
-						<property type="associationTypes" name="beginType"/>
-						<property type="associationTypes" name="endType"/>
+						<property type="associationTypes" name="beginType">
+							<default>no_arrow</default>
+						</property>
+						<property type="associationTypes" name="endType">
+							<default>no_arrow</default>
+						</property>
 						<property type="string" name="beginName"/>
 						<property type="string" name="endName"/>
 					</properties>


### PR DESCRIPTION
from empty string to "no_arrow" since latter is the default value for it in gui
and someone intending to set its value no "no_arrow" might end up with broken generated xml
