### PR TITLE
- Settings Manager now prefers default settings from .ini files over def...

### DIFF
--- a/qrgui/umllib/label.cpp
+++ b/qrgui/umllib/label.cpp
@@ -39,7 +39,9 @@ Label::~Label()
 
 void Label::init()
 {
-	QGraphicsTextItem::setFlags(ItemIsSelectable | ItemIsMovable);
+	QGraphicsTextItem::setFlags(ItemIsSelectable);
+	QGraphicsTextItem::setFlag(ItemIsMovable, SettingsManager::value("MoveLabels", true).toBool());
+
 	setTitleFont();
 	setRotation(mRotation);
 	if (!mBinding.isEmpty()) {

--- a/qrgui/umllib/label.h
+++ b/qrgui/umllib/label.h
@@ -18,7 +18,7 @@ public:
 	Label(models::GraphicalModelAssistApi &graphicalAssistApi, Id const &elementId
 			, int index, qreal x, qreal y, QString const &binding, bool readOnly, qreal rotation);
 
-	virtual ~Label();
+	~Label() override;
 
 	void init(QRectF const &contents);
 	void setBackground(QColor const &background);

--- a/qrkernel/settingsManager.cpp
+++ b/qrkernel/settingsManager.cpp
@@ -59,7 +59,7 @@ QVariant SettingsManager::get(QString const &name, QVariant const &defaultValue)
 		return mData[name];
 	}
 
-	if (mDefaultValues.contains(name) && defaultValue == QVariant()) {
+	if (mDefaultValues.contains(name)) {
 		return mDefaultValues[name];
 	}
 


### PR DESCRIPTION
...ault settings from code, so, for example, labels are not movable for robots
- when labels are not movable it will not be possible to move them by including them by rubber band selection without their nodes
