### PR TITLE
Made semantic analyzer be called even for cached ASTs (since underlying ...

### DIFF
--- a/qrtext/include/qrtext/core/semantics/semanticAnalyzer.h
+++ b/qrtext/include/qrtext/core/semantics/semanticAnalyzer.h
@@ -65,6 +65,9 @@ public:
 	/// Returns type for a given expression (if that expression was seen by "analyze" method before, or nullptr).
 	QSharedPointer<types::TypeExpression> type(QSharedPointer<ast::Node> const &expression) const;
 
+	/// Returns list of identifier names known to semantic analyzer.
+	QStringList identifiers() const;
+
 protected:
 	/// Assigns given type to given expression.
 	void assign(QSharedPointer<ast::Node> const &expression, QSharedPointer<types::TypeExpression> const &type);

--- a/qrtext/src/core/semantics/semanticAnalyzer.cpp
+++ b/qrtext/src/core/semantics/semanticAnalyzer.cpp
@@ -69,6 +69,11 @@ QSharedPointer<types::TypeExpression> SemanticAnalyzer::type(QSharedPointer<ast:
 	}
 }
 
+QStringList SemanticAnalyzer::identifiers() const
+{
+	return mIdentifierDeclarations.keys();
+}
+
 void SemanticAnalyzer::assign(QSharedPointer<ast::Node> const &expression
 		, QSharedPointer<types::TypeExpression> const &type)
 {

--- a/qrtext/src/lua/luaToolbox.cpp
+++ b/qrtext/src/lua/luaToolbox.cpp
@@ -45,21 +45,25 @@ QSharedPointer<Node> const &LuaToolbox::parse(qReal::Id const &id, QString const
 {
 	mErrors.clear();
 
+	QSharedPointer<Node> ast;
+
 	if (mParsedCache[id][propertyName] != code) {
 		auto tokenStream = mLexer->tokenize(code);
-		auto ast = mParser->parse(tokenStream);
+		ast = mParser->parse(tokenStream);
 
 		if (mErrors.isEmpty()) {
 			mAstRoots[id][propertyName] = ast;
-			/// Note that analyze() changes mErrors, so these two ifs are correct.
-			mAnalyzer->analyze(ast);
 		}
 
-		if (mErrors.isEmpty()) {
-			mParsedCache[id][propertyName] = code;
-		} else {
-			reportErrors();
-		}
+		mParsedCache[id][propertyName] = code;
+	} else {
+		ast = mAstRoots[id][propertyName];
+	}
+
+	mAnalyzer->analyze(ast);
+	if (!mErrors.isEmpty()) {
+		mParsedCache[id].remove(propertyName);
+		reportErrors();
 	}
 
 	return mAstRoots[id][propertyName];
@@ -101,7 +105,7 @@ void LuaToolbox::addIntrinsicFunction(QString const &name
 
 QStringList LuaToolbox::identifiers() const
 {
-	return mInterpreter->identifiers();
+	return mAnalyzer->identifiers();
 }
 
 QVariant LuaToolbox::value(QString const &identifier) const


### PR DESCRIPTION
...runtime may change), made identifiers() use semantic analyzer instead of interpreter
