### PR TITLE
double restore diagram bug is fixed

### DIFF
--- a/qrgui/mainWindow/projectManager/autosaver.cpp
+++ b/qrgui/mainWindow/projectManager/autosaver.cpp
@@ -140,6 +140,7 @@ bool Autosaver::checkTempFile()
 	}
 	if (QMessageBox::question(QApplication::activeWindow(), tr("Question")
 			, openTempFilePrompt()) != QMessageBox::Yes) {
+		QFile(tempFileInfo.absoluteFilePath()).remove();
 		return false;
 	}
 	return openTemp();


### PR DESCRIPTION
Double restore of a autosaved diagram is fixed to restore once, when opening studio.
