### PR TITLE
Hotkey support for elements

### DIFF
--- a/plugins/robots/editor/generated/robotsMetamodel.xml
+++ b/plugins/robots/editor/generated/robotsMetamodel.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <metamodel xmlns="http://schema.real.com/schema/" version="3.1.0">
 	<include>../../../commonMetamodels/kernelMetamodel.xml</include>
 	<include>../../../commonMetamodels/basicBehaviorsMetamodel.xml</include>
@@ -635,7 +635,7 @@
 					</generalizations>
 				</logic>
 			</node>
-			<node displayedName="Motors Backward" name="NxtEnginesBackward" path="111, 224 : 0, 113 :  | 113, 0 : 0, 113 :  | 0, 113 : 287, 113 : " description="Enables motors on the given ports in reverse mode with the given power. Ports are specified with A, B or C letters divided by commas. The power is specified in percents with the number from -100 to 100, if negative number is specified then the motor is enabled in the usual mode.">
+			<node displayedName="Motors Backward" name="NxtEnginesBackward" path="111, 224 : 0, 113 :  | 113, 0 : 0, 113 :  | 0, 113 : 287, 113 : " description="Enables motors on the given ports in reverse mode with the given power. Ports are specified with A, B or C letters divided by commas. The power is specified in percents with the number from -100 to 100, if negative number is specified then the motor is enabled in the usual mode." hotKey = "Ctrl+J">
 				<graphics>
 					<picture sizex="50" sizey="50">
 						<image y1="0" name="images/enginesBackwardBlock.png" x1="0" y2="50" x2="50"/>
@@ -767,7 +767,7 @@
 					</picture>
 					<labels>
 						<label x="25" y="-35" textBinded="Ports" hard="true" background="white" prefix="Ports:"/>
-						<label x="35" y="60" textBinded="Power" background="white" prefix="Power:" suffix="%"/>
+						<label x="35" y="60" textBinded="Power" background="white" prefix="Power:" siffux="%"/>
 					</labels>
 					<nonResizeable/>
 				</graphics>
@@ -916,7 +916,7 @@
 					</generalizations>
 				</logic>
 			</node>
-			<node displayedName="Play Tone" name="NxtPlayTone" path="130, 62 : 130, 146 :  | 106, 0 : 106, 212 :  | 0, 106 : 106, 212 :  | 0, 106 : 106, 0 : " description="Plays on the robot a sound with the given frequency and duration. This block is similar to the 'Beep' block wuth the only difference that here you can specify sound parameters.">
+			<node displayedName="Play Tone" name="NxtPlayTone" path="130, 62 : 130, 146 :  | 106, 0 : 106, 212 :  | 0, 106 : 106, 212 :  | 0, 106 : 106, 0 : " description="Plays on the robot a sound with the given frequency and duration. This block is similar to the 'Beep' block wuth the only difference that here you can specify sound parameters." hotKey = "Ctrl+K, Shift+C">
 				<graphics>
 					<picture sizex="50" sizey="50">
 						<image y1="0" name="images/playToneBlock.png" x1="0" y2="50" x2="50"/>
@@ -950,7 +950,7 @@
 					</generalizations>
 				</logic>
 			</node>
-			<node displayedName="Beep" name="Ev3Beep" path="152, 12 : 281, 12 :  | 152, 183 : 152, 12 :  | 155, 170 : 154, 176 : 153, 183 : 151, 190 : 149, 196 : 146, 202 : 143, 208 : 139, 214 : 134, 219 : 129, 224 : 123, 228 : 117, 231 : 111, 234 : 105, 236 : 98, 238 : 91, 239 : 85, 239 : 79, 239 : 72, 238 : 65, 236 : 59, 234 : 53, 231 : 47, 228 : 41, 224 : 36, 219 : 31, 214 : 27, 208 : 24, 202 : 21, 196 : 19, 190 : 17, 183 : 16, 176 : 16, 170 : 16, 164 : 17, 157 : 19, 150 : 21, 144 : 24, 138 : 27, 132 : 31, 126 : 36, 121 : 41, 116 : 47, 112 : 53, 109 : 59, 106 : 65, 104 : 72, 102 : 79, 101 : 85, 101 : 91, 101 : 98, 102 : 105, 104 : 111, 106 : 117, 109 : 123, 112 : 129, 116 : 134, 121 : 139, 126 : 143, 132 : 146, 138 : 149, 144 : 151, 150 : 153, 157 : 154, 164 : 155, 170 : " description="Plays on the robot a sound with the fixed frequency. There are two parameters. The first one is a loudness of the sound, the second means if program should wait for sound completion or go to next block right away.">
+			<node displayedName="Beep" name="Ev3Beep" path="152, 12 : 281, 12 :  | 152, 183 : 152, 12 :  | 155, 170 : 154, 176 : 153, 183 : 151, 190 : 149, 196 : 146, 202 : 143, 208 : 139, 214 : 134, 219 : 129, 224 : 123, 228 : 117, 231 : 111, 234 : 105, 236 : 98, 238 : 91, 239 : 85, 239 : 79, 239 : 72, 238 : 65, 236 : 59, 234 : 53, 231 : 47, 228 : 41, 224 : 36, 219 : 31, 214 : 27, 208 : 24, 202 : 21, 196 : 19, 190 : 17, 183 : 16, 176 : 16, 170 : 16, 164 : 17, 157 : 19, 150 : 21, 144 : 24, 138 : 27, 132 : 31, 126 : 36, 121 : 41, 116 : 47, 112 : 53, 109 : 59, 106 : 65, 104 : 72, 102 : 79, 101 : 85, 101 : 91, 101 : 98, 102 : 105, 104 : 111, 106 : 117, 109 : 123, 112 : 129, 116 : 134, 121 : 139, 126 : 143, 132 : 146, 138 : 149, 144 : 151, 150 : 153, 157 : 154, 164 : 155, 170 : " description="Plays on the robot a sound with the fixed frequency. There are two parameters. The first one is a loudness of the sound, the second means if program should wait for sound completion or go to next block right away." hotKey = "Ctrl+F">
 				<graphics>
 					<picture sizex="50" sizey="50">
 						<image y1="0" name="images/beepBlock.png" x1="0" y2="50" x2="50"/>
@@ -1961,7 +1961,6 @@
 						<label x="30" y="60" textBinded="Variable" hard="true" prefix="Variable:"/>
 						<label x="30" y="90" textBinded="Wait" hard="true" prefix="Wait:"/>
 					</labels>
-					<nonResizeable/>
 				</graphics>
 				<logic>
 					<container/>
@@ -2393,7 +2392,7 @@
 				<logic>
 					<container/>
 					<properties>
-						<property displayedName="Width" type="string" name="Width">
+						<property displayedName="Width" type="int" name="Width">
 							<default>1</default>
 						</property>
 					</properties>
@@ -2416,10 +2415,10 @@
 				<logic>
 					<container/>
 					<properties>
-						<property displayedName="X" type="string" name="XCoordinatePix">
+						<property displayedName="X" type="int" name="XCoordinatePix">
 							<default>5</default>
 						</property>
-						<property displayedName="Y" type="string" name="YCoordinatePix">
+						<property displayedName="Y" type="int" name="YCoordinatePix">
 							<default>5</default>
 						</property>
 						<property displayedName="Redraw" type="bool" name="Redraw">
@@ -2447,16 +2446,16 @@
 				<logic>
 					<container/>
 					<properties>
-						<property displayedName="X1" type="string" name="X1CoordinateLine">
+						<property displayedName="X1" type="int" name="X1CoordinateLine">
 							<default>0</default>
 						</property>
-						<property displayedName="Y1" type="string" name="Y1CoordinateLine">
+						<property displayedName="Y1" type="int" name="Y1CoordinateLine">
 							<default>0</default>
 						</property>
-						<property displayedName="X2" type="string" name="X2CoordinateLine">
+						<property displayedName="X2" type="int" name="X2CoordinateLine">
 							<default>10</default>
 						</property>
-						<property displayedName="Y2" type="string" name="Y2CoordinateLine">
+						<property displayedName="Y2" type="int" name="Y2CoordinateLine">
 							<default>10</default>
 						</property>
 						<property displayedName="Redraw" type="bool" name="Redraw">
@@ -2484,16 +2483,16 @@
 				<logic>
 					<container/>
 					<properties>
-						<property displayedName="X" type="string" name="XCoordinateRect">
+						<property displayedName="X" type="int" name="XCoordinateRect">
 							<default>0</default>
 						</property>
-						<property displayedName="Y" type="string" name="YCoordinateRect">
+						<property displayedName="Y" type="int" name="YCoordinateRect">
 							<default>0</default>
 						</property>
-						<property displayedName="Width" type="string" name="WidthRect">
+						<property displayedName="Width" type="int" name="WidthRect">
 							<default>5</default>
 						</property>
-						<property displayedName="Height" type="string" name="HeightRect">
+						<property displayedName="Height" type="int" name="HeightRect">
 							<default>5</default>
 						</property>
 						<property displayedName="Redraw" type="bool" name="Redraw">
@@ -2521,16 +2520,16 @@
 				<logic>
 					<container/>
 					<properties>
-						<property displayedName="X" type="string" name="XCoordinateEllipse">
+						<property displayedName="X" type="int" name="XCoordinateEllipse">
 							<default>0</default>
 						</property>
-						<property displayedName="Y" type="string" name="YCoordinateEllipse">
+						<property displayedName="Y" type="int" name="YCoordinateEllipse">
 							<default>0</default>
 						</property>
-						<property displayedName="Width" type="string" name="WidthEllipse">
+						<property displayedName="Width" type="int" name="WidthEllipse">
 							<default>5</default>
 						</property>
-						<property displayedName="Height" type="string" name="HeightEllipse">
+						<property displayedName="Height" type="int" name="HeightEllipse">
 							<default>5</default>
 						</property>
 						<property displayedName="Redraw" type="bool" name="Redraw">
@@ -2560,16 +2559,16 @@
 				<logic>
 					<container/>
 					<properties>
-						<property displayedName="X" type="string" name="XCoordinateArc">
+						<property displayedName="X" type="int" name="XCoordinateArc">
 							<default>0</default>
 						</property>
-						<property displayedName="Y" type="string" name="YCoordinateArc">
+						<property displayedName="Y" type="int" name="YCoordinateArc">
 							<default>0</default>
 						</property>
-						<property displayedName="Width" type="string" name="WidthArc">
+						<property displayedName="Width" type="int" name="WidthArc">
 							<default>5</default>
 						</property>
-						<property displayedName="Height" type="string" name="HeightArc">
+						<property displayedName="Height" type="int" name="HeightArc">
 							<default>5</default>
 						</property>
 						<property displayedName="StartAngle" type="int" name="StartAngle">
@@ -2758,7 +2757,6 @@
 				<element name="SendMessageThreads"/>
 				<element name="TrikWriteToFile"/>
 				<element name="TrikRemoveFile"/>
-				<element name="GetButtonCode"/>
 			</group>
 			<group name="Wait">
 				<element name="Timer"/>
@@ -2788,6 +2786,7 @@
 				<element name="TrikWaitGamepadDisconnect" />
 				<element name="TrikWaitGamepadConnect" />
 				<element name="ReceiveMessageThreads"/>
+				<element name="GetButtonCode"/>
 			</group>
 			<group name="Drawing">
 				<element name="NxtDrawRect"/>

--- a/qrgui/mainWindow/mainWindow.cpp
+++ b/qrgui/mainWindow/mainWindow.cpp
@@ -341,7 +341,7 @@ void MainWindow::loadPlugins()
 			, SettingsManager::value("PaletteIconsInARowCount").toInt()
 			, &editorManager());
 	SettingsManager::setValue("EditorsLoadedCount", editorManager().editors().count());
-    loadElementsShortcuts();
+	loadElementsShortcuts();
 }
 
 void MainWindow::clearSelectionOnTabs()

--- a/qrgui/mainWindow/mainWindow.cpp
+++ b/qrgui/mainWindow/mainWindow.cpp
@@ -753,7 +753,7 @@ bool MainWindow::pluginLoaded(const QString &pluginName)
 
 EditorView * MainWindow::getCurrentTab() const
 {
-    return dynamic_cast<EditorView *>(mUi->tabs->currentWidget());
+	return dynamic_cast<EditorView *>(mUi->tabs->currentWidget());
 }
 
 bool MainWindow::isCurrentTabShapeEdit() const
@@ -1097,32 +1097,28 @@ void MainWindow::setShortcuts(EditorView * const tab)
 	QAction *selectAction = new QAction(tab);
 	selectAction->setShortcut(QKeySequence(Qt::CTRL | Qt::Key_A));
 	connect(selectAction, SIGNAL(triggered()), scene, SLOT(selectAll()));
-    tab->addAction(selectAction);
+	tab->addAction(selectAction);
 }
 
 void MainWindow::loadElementsShortcuts()
 {
-    foreach (Id editor, editorManager().editors())
-        foreach (Id diagram, editorManager().diagrams(editor))
-            foreach(Id element, editorManager().elements(diagram)) {
-                QAction *action = new QAction(this);
-                QList<QKeySequence> hotKeyList;
-                foreach (QString string, editorManager().hotKey(element).split(", "))
-                    hotKeyList << QKeySequence(string);
-                action->setShortcuts(hotKeyList);
-                connect(action, &QAction::triggered, [=]()
-                {
-                        // TODO: add check for whether it is legit to create element on current tab
-
-
-                    if (editorManager().isElementEnabled(element))
-                        getCurrentTab()->mutableScene().createElement(element.type().toString()
-                        , getCurrentTab()->mutableScene().getMousePos());
-                });
-                this->addAction(action);
-                HotKeyManager::setCommand("Scene." + element.element(), "Create " + element.element(), action);
-
-            }
+	foreach (Id editor, editorManager().editors())
+		foreach (Id diagram, editorManager().diagrams(editor))
+			foreach(Id element, editorManager().elements(diagram)) {
+				QAction *action = new QAction(this);
+				QList<QKeySequence> hotKeyList;
+				foreach (QString string, editorManager().hotKey(element).split(", "))
+					hotKeyList << QKeySequence(string);
+				action->setShortcuts(hotKeyList);
+				connect(action, &QAction::triggered, [=]()
+				{
+					if (editorManager().isElementEnabled(element))
+						getCurrentTab()->mutableScene().createElement(element.type().toString()
+						, getCurrentTab()->mutableScene().getMousePos());
+				});
+				this->addAction(action);
+				HotKeyManager::setCommand("Scene." + element.element(), "Create " + element.element(), action);
+			}
 }
 
 void MainWindow::setDefaultShortcuts()

--- a/qrgui/mainWindow/mainWindow.cpp
+++ b/qrgui/mainWindow/mainWindow.cpp
@@ -753,7 +753,7 @@ bool MainWindow::pluginLoaded(const QString &pluginName)
 
 EditorView * MainWindow::getCurrentTab() const
 {
-	return dynamic_cast<EditorView *>(mUi->tabs->currentWidget());
+    return dynamic_cast<EditorView *>(mUi->tabs->currentWidget());
 }
 
 bool MainWindow::isCurrentTabShapeEdit() const
@@ -1113,8 +1113,11 @@ void MainWindow::loadElementsShortcuts()
                 connect(action, &QAction::triggered, [=]()
                 {
                         // TODO: add check for whether it is legit to create element on current tab
-                       getCurrentTab()->mutableScene().createElement(element.type().toString()
-                                                                  , getCurrentTab()->mutableScene().getMousePos());
+
+
+                    if (editorManager().isElementEnabled(element))
+                        getCurrentTab()->mutableScene().createElement(element.type().toString()
+                        , getCurrentTab()->mutableScene().getMousePos());
                 });
                 this->addAction(action);
                 HotKeyManager::setCommand("Scene." + element.element(), "Create " + element.element(), action);

--- a/qrgui/mainWindow/mainWindow.h
+++ b/qrgui/mainWindow/mainWindow.h
@@ -298,8 +298,8 @@ private:
 	/// @param tab Tab to be initialized with shortcuts
 	void setShortcuts(EditorView * const tab);
 
-    /// Loads shortcuts for each element given from language metamodels xmls.
-    void loadElementsShortcuts();
+	/// Loads shortcuts for each element given from language metamodels xmls.
+	void loadElementsShortcuts();
 
 	void setDefaultShortcuts();
 

--- a/qrgui/mainWindow/mainWindow.h
+++ b/qrgui/mainWindow/mainWindow.h
@@ -298,6 +298,9 @@ private:
 	/// @param tab Tab to be initialized with shortcuts
 	void setShortcuts(EditorView * const tab);
 
+    /// Loads shortcuts for each element given from language metamodels xmls.
+    void loadElementsShortcuts();
+
 	void setDefaultShortcuts();
 
 	void registerMetaTypes();

--- a/qrgui/plugins/editorPluginInterface/editorInterface.h
+++ b/qrgui/plugins/editorPluginInterface/editorInterface.h
@@ -79,6 +79,7 @@ public:
 	virtual QString diagramNodeName(const QString &diagram) const = 0;
 	virtual QString elementName(const QString &diagram, const QString &element) const = 0;
 	virtual QString elementMouseGesture(const QString &diagram, const QString &element) const = 0;
+    virtual QString elementHotKey(const QString &diagram, const QString &element) const = 0;
 	virtual QString elementDescription(const QString &diagram, const QString &element) const = 0;
 	virtual QString propertyDescription(const QString &diagram, const QString &element
 			, const QString &property) const = 0;

--- a/qrgui/plugins/editorPluginInterface/editorInterface.h
+++ b/qrgui/plugins/editorPluginInterface/editorInterface.h
@@ -79,7 +79,7 @@ public:
 	virtual QString diagramNodeName(const QString &diagram) const = 0;
 	virtual QString elementName(const QString &diagram, const QString &element) const = 0;
 	virtual QString elementMouseGesture(const QString &diagram, const QString &element) const = 0;
-    virtual QString elementHotKey(const QString &diagram, const QString &element) const = 0;
+	virtual QString elementHotKey(const QString &diagram, const QString &element) const = 0;
 	virtual QString elementDescription(const QString &diagram, const QString &element) const = 0;
 	virtual QString propertyDescription(const QString &diagram, const QString &element
 			, const QString &property) const = 0;

--- a/qrgui/plugins/pluginManager/editorManager.cpp
+++ b/qrgui/plugins/pluginManager/editorManager.cpp
@@ -68,23 +68,7 @@ QString EditorManager::loadPlugin(const QString &pluginName)
 
 QString EditorManager::unloadPlugin(const QString &pluginName)
 {
-	QString resultOfUnloading = "";
-	if (!mPluginFileName[pluginName].isEmpty()) {
-		resultOfUnloading = mPluginManager.unloadPlugin(mPluginFileName[pluginName]);
-	} else {
-		const QList<QString> namesOfPlugins = mPluginManager.namesOfPlugins();
-		const QString tempName = pluginName.toLower();
-		QString newPluginName = "";
-
-		for (const QString &element : namesOfPlugins) {
-			if (element.contains(tempName) && !element.contains(".a")) {
-				newPluginName = element;
-				break;
-			}
-		}
-
-		resultOfUnloading = mPluginManager.unloadPlugin(newPluginName);
-	}
+	const QString resultOfUnloading = mPluginManager.unloadPlugin(mPluginFileName[pluginName]);
 
 	if (mPluginIface.keys().contains(pluginName)) {
 		mPluginIface.remove(pluginName);
@@ -241,7 +225,16 @@ QString EditorManager::mouseGesture(const Id &id) const
 	if (id.idSize() != 3) {
 		return "";
 	}
-	return mPluginIface[id.editor()]->elementMouseGesture(id.diagram(), id.element());
+    return mPluginIface[id.editor()]->elementMouseGesture(id.diagram(), id.element());
+}
+
+QString EditorManager::hotKey(const Id &id) const
+{
+    Q_ASSERT(mPluginsLoaded.contains(id.editor()));
+    if (id.idSize() != 3) {
+        return "";
+    }
+    return mPluginIface[id.editor()]->elementHotKey(id.diagram(), id.element());
 }
 
 QIcon EditorManager::icon(const Id &id) const
@@ -678,18 +671,6 @@ IdList EditorManager::propertiesWithTheSameName(const Id &id, const QString &pro
 	Q_UNUSED(propertyCurrentName);
 	Q_UNUSED(propertyNewName);
 	return IdList();
-}
-
-void EditorManager::updateGenerationRule(const Id &id, const QString &newRule) const
-{
-	Q_UNUSED(id);
-	Q_UNUSED(newRule);
-}
-
-QString EditorManager::generationRule(const Id &id) const
-{
-	Q_UNUSED(id);
-	return QString();
 }
 
 QStringList EditorManager::getPropertiesInformation(const Id &id) const

--- a/qrgui/plugins/pluginManager/editorManager.cpp
+++ b/qrgui/plugins/pluginManager/editorManager.cpp
@@ -225,16 +225,16 @@ QString EditorManager::mouseGesture(const Id &id) const
 	if (id.idSize() != 3) {
 		return "";
 	}
-    return mPluginIface[id.editor()]->elementMouseGesture(id.diagram(), id.element());
+	return mPluginIface[id.editor()]->elementMouseGesture(id.diagram(), id.element());
 }
 
 QString EditorManager::hotKey(const Id &id) const
 {
-    Q_ASSERT(mPluginsLoaded.contains(id.editor()));
-    if (id.idSize() != 3) {
-        return "";
-    }
-    return mPluginIface[id.editor()]->elementHotKey(id.diagram(), id.element());
+	Q_ASSERT(mPluginsLoaded.contains(id.editor()));
+	if (id.idSize() != 3) {
+		return "";
+	}
+	return mPluginIface[id.editor()]->elementHotKey(id.diagram(), id.element());
 }
 
 QIcon EditorManager::icon(const Id &id) const
@@ -703,10 +703,10 @@ void EditorManager::setElementEnabled(const Id &type, bool enabled)
 		mDisabledElements.remove(type);
 	} else {
 		mDisabledElements.insert(type);
-    }
+	}
 }
 
 bool EditorManager::isElementEnabled(const Id &element)
 {
-    return !mDisabledElements.contains(element);
+	return !mDisabledElements.contains(element);
 }

--- a/qrgui/plugins/pluginManager/editorManager.cpp
+++ b/qrgui/plugins/pluginManager/editorManager.cpp
@@ -703,5 +703,10 @@ void EditorManager::setElementEnabled(const Id &type, bool enabled)
 		mDisabledElements.remove(type);
 	} else {
 		mDisabledElements.insert(type);
-	}
+    }
+}
+
+bool EditorManager::isElementEnabled(const Id &element)
+{
+    return !mDisabledElements.contains(element);
 }

--- a/qrgui/plugins/pluginManager/editorManager.h
+++ b/qrgui/plugins/pluginManager/editorManager.h
@@ -61,6 +61,7 @@ public:
 	QString unloadPlugin(const QString &pluginName) override;
 
 	QString mouseGesture(const Id &id) const override;
+    QString hotKey(const Id &id) const override;
 	QString friendlyName(const Id &id) const override;
 	QString description(const Id &id) const override;
 	QString propertyDescription(const Id &id, const QString &propertyName) const override;
@@ -133,9 +134,6 @@ public:
 	IdList elementsWithTheSameName(const Id &diagram, const QString &name, const QString type) const override;
 	IdList propertiesWithTheSameName(const Id &id
 			, const QString &propertyCurrentName, const QString &propertyNewName) const override;
-
-	void updateGenerationRule(const Id &id, const QString &newRule) const override;
-	QString generationRule(const Id &id) const override;
 
 	QStringList getPropertiesInformation(const Id &id) const override;
 	QStringList getSameNamePropertyParams(const Id &propertyId, const QString &propertyName) const override;

--- a/qrgui/plugins/pluginManager/editorManager.h
+++ b/qrgui/plugins/pluginManager/editorManager.h
@@ -61,7 +61,7 @@ public:
 	QString unloadPlugin(const QString &pluginName) override;
 
 	QString mouseGesture(const Id &id) const override;
-    QString hotKey(const Id &id) const override;
+	QString hotKey(const Id &id) const override;
 	QString friendlyName(const Id &id) const override;
 	QString description(const Id &id) const override;
 	QString propertyDescription(const Id &id, const QString &propertyName) const override;
@@ -142,7 +142,7 @@ public:
 
 	void setElementEnabled(const Id &type, bool enabled) override;
 
-    bool isElementEnabled(const Id &element) override;
+	bool isElementEnabled(const Id &element) override;
 
 private:
 	EditorInterface *editorInterface(const QString &editor) const;

--- a/qrgui/plugins/pluginManager/editorManager.h
+++ b/qrgui/plugins/pluginManager/editorManager.h
@@ -142,6 +142,8 @@ public:
 
 	void setElementEnabled(const Id &type, bool enabled) override;
 
+    bool isElementEnabled(const Id &element) override;
+
 private:
 	EditorInterface *editorInterface(const QString &editor) const;
 

--- a/qrgui/plugins/pluginManager/editorManagerInterface.h
+++ b/qrgui/plugins/pluginManager/editorManagerInterface.h
@@ -143,6 +143,8 @@ public:
 
 	/// Includes or excludes element from metamodel.
 	virtual void setElementEnabled(const Id &type, bool enabled) = 0;
+
+    virtual bool isElementEnabled(const Id &element) = 0;
 };
 
 

--- a/qrgui/plugins/pluginManager/editorManagerInterface.h
+++ b/qrgui/plugins/pluginManager/editorManagerInterface.h
@@ -55,6 +55,7 @@ public:
 	virtual QString unloadPlugin(const QString &pluginName) = 0;
 
 	virtual QString mouseGesture(const Id &id) const = 0;
+    virtual QString hotKey(const Id &id) const = 0;
 	virtual QString friendlyName(const Id &id) const = 0;
 	virtual QString description(const Id &id) const = 0;
 	virtual QString propertyDescription(const Id &id, const QString &propertyName) const = 0;
@@ -72,15 +73,6 @@ public:
 	virtual bool isEditor(const Id &id) const = 0;
 	virtual bool isDiagram(const Id &id) const = 0;
 	virtual bool isElement(const Id &id) const = 0;
-
-	/// Updates generation rule for given element.
-	/// @param id - element id.
-	/// @param newRule - new generation rule.
-	virtual void updateGenerationRule(const Id &id, const QString &newRule) const = 0;
-
-	/// Returns rule for given element.
-	/// @param id - element id.
-	virtual QString generationRule(const Id &id) const = 0;
 
 	virtual QStringList propertyNames(const Id &id) const = 0;
 	virtual QStringList portTypes(const Id &id) const = 0;

--- a/qrgui/plugins/pluginManager/editorManagerInterface.h
+++ b/qrgui/plugins/pluginManager/editorManagerInterface.h
@@ -55,7 +55,7 @@ public:
 	virtual QString unloadPlugin(const QString &pluginName) = 0;
 
 	virtual QString mouseGesture(const Id &id) const = 0;
-    virtual QString hotKey(const Id &id) const = 0;
+	virtual QString hotKey(const Id &id) const = 0;
 	virtual QString friendlyName(const Id &id) const = 0;
 	virtual QString description(const Id &id) const = 0;
 	virtual QString propertyDescription(const Id &id, const QString &propertyName) const = 0;
@@ -144,7 +144,7 @@ public:
 	/// Includes or excludes element from metamodel.
 	virtual void setElementEnabled(const Id &type, bool enabled) = 0;
 
-    virtual bool isElementEnabled(const Id &element) = 0;
+	virtual bool isElementEnabled(const Id &element) = 0;
 };
 
 

--- a/qrgui/plugins/pluginManager/interpreterEditorManager.cpp
+++ b/qrgui/plugins/pluginManager/interpreterEditorManager.cpp
@@ -270,17 +270,17 @@ QString InterpreterEditorManager::mouseGesture(const Id &id) const
 		return repoAndMetaIdPair.first->stringProperty(repoAndMetaIdPair.second, "path");
 	}
 
-    return "";
+	return "";
 }
 
 QString InterpreterEditorManager::hotKey(const Id &id) const
 {
-    QPair<qrRepo::RepoApi*, Id> const repoAndMetaIdPair = repoAndMetaId(id);
-    if (repoAndMetaIdPair.first->hasProperty(repoAndMetaIdPair.second, "hotKey")) {
-        return repoAndMetaIdPair.first->stringProperty(repoAndMetaIdPair.second, "hotKey");
-    }
+	QPair<qrRepo::RepoApi*, Id> const repoAndMetaIdPair = repoAndMetaId(id);
+	if (repoAndMetaIdPair.first->hasProperty(repoAndMetaIdPair.second, "hotKey")) {
+		return repoAndMetaIdPair.first->stringProperty(repoAndMetaIdPair.second, "hotKey");
+	}
 
-    return "";
+	return "";
 }
 
 
@@ -940,13 +940,13 @@ void InterpreterEditorManager::restoreRenamedProperty(const Id &propertyId, cons
 void InterpreterEditorManager::setElementEnabled(const Id &type, bool enabled)
 {
 	Q_UNUSED(type)
-    Q_UNUSED(enabled)
+	Q_UNUSED(enabled)
 }
 
 bool InterpreterEditorManager::isElementEnabled(const Id &element)
 {
-    Q_UNUSED(element);
-    return bool();
+	Q_UNUSED(element);
+	return bool();
 }
 
 QMap<QString, qrRepo::RepoApi*> InterpreterEditorManager::listOfMetamodels() const

--- a/qrgui/plugins/pluginManager/interpreterEditorManager.cpp
+++ b/qrgui/plugins/pluginManager/interpreterEditorManager.cpp
@@ -270,7 +270,17 @@ QString InterpreterEditorManager::mouseGesture(const Id &id) const
 		return repoAndMetaIdPair.first->stringProperty(repoAndMetaIdPair.second, "path");
 	}
 
-	return "";
+    return "";
+}
+
+QString InterpreterEditorManager::hotKey(const Id &id) const
+{
+    QPair<qrRepo::RepoApi*, Id> const repoAndMetaIdPair = repoAndMetaId(id);
+    if (repoAndMetaIdPair.first->hasProperty(repoAndMetaIdPair.second, "hotKey")) {
+        return repoAndMetaIdPair.first->stringProperty(repoAndMetaIdPair.second, "hotKey");
+    }
+
+    return "";
 }
 
 
@@ -1117,7 +1127,6 @@ void InterpreterEditorManager::addNodeElement(const Id &diagram, const QString &
 	repo->setProperty(nodeId, "links", IdListHelper::toVariant(IdList()));
 	repo->setProperty(nodeId, "createChildrenFromMenu", "false");
 	repo->setProperty(nodeId, "isHidden", "false");
-
 	foreach (const Id &elem, repo->children(diag)) {
 		if (repo->name(elem) == "AbstractNode" && repo->isLogicalElement(elem)) {
 			const Id inheritanceLink("MetaEditor", "MetaEditor", "Inheritance", QUuid::createUuid().toString());
@@ -1137,7 +1146,7 @@ void InterpreterEditorManager::addEdgeElement(const Id &diagram, const QString &
 		, const QString &displayedName, const QString &labelText, const QString &labelType
 		, const QString &lineType, const QString &beginType, const QString &endType) const
 {
-	const QPair<qrRepo::RepoApi*, Id> repoAndDiagramPair = repoAndDiagram(diagram.editor(), diagram.diagram());
+	QPair<qrRepo::RepoApi*, Id> const repoAndDiagramPair = repoAndDiagram(diagram.editor(), diagram.diagram());
 	qrRepo::RepoApi * const repo = repoAndDiagramPair.first;
 	const Id diag = repoAndDiagramPair.second;
 	Id edgeId("MetaEditor", "MetaEditor", "MetaEntityEdge", QUuid::createUuid().toString());
@@ -1157,26 +1166,6 @@ void InterpreterEditorManager::addEdgeElement(const Id &diagram, const QString &
 	repo->setProperty(associationId, "name", name + "Association");
 	repo->setProperty(associationId, "beginType", beginType);
 	repo->setProperty(associationId, "endType", endType);
-}
-
-void InterpreterEditorManager::updateGenerationRule(const Id &id, const QString &newRule) const
-{
-	const QPair<qrRepo::RepoApi*, Id> repoAndMetaIdPair = repoAndMetaId(id);
-	if (repoAndMetaIdPair.second.element() == "MetaEntityNode") {
-		repoAndMetaIdPair.first->setProperty(repoAndMetaIdPair.second, "generationRule", newRule);
-	}
-}
-
-QString InterpreterEditorManager::generationRule(const Id &id) const
-{
-	const QPair<qrRepo::RepoApi*, Id> repoAndMetaIdPair = repoAndMetaId(id);
-	const qrRepo::RepoApi * const repo = repoAndMetaIdPair.first;
-	const Id metaId = repoAndMetaIdPair.second;
-	if (metaId.element() == "MetaEntityNode") {
-		return repo->stringProperty(metaId, "generationRule");
-	}
-
-	return "";
 }
 
 QPair<Id, Id> InterpreterEditorManager::createEditorAndDiagram(const QString &name) const

--- a/qrgui/plugins/pluginManager/interpreterEditorManager.cpp
+++ b/qrgui/plugins/pluginManager/interpreterEditorManager.cpp
@@ -940,7 +940,13 @@ void InterpreterEditorManager::restoreRenamedProperty(const Id &propertyId, cons
 void InterpreterEditorManager::setElementEnabled(const Id &type, bool enabled)
 {
 	Q_UNUSED(type)
-	Q_UNUSED(enabled)
+    Q_UNUSED(enabled)
+}
+
+bool InterpreterEditorManager::isElementEnabled(const Id &element)
+{
+    Q_UNUSED(element);
+    return bool();
 }
 
 QMap<QString, qrRepo::RepoApi*> InterpreterEditorManager::listOfMetamodels() const

--- a/qrgui/plugins/pluginManager/interpreterEditorManager.h
+++ b/qrgui/plugins/pluginManager/interpreterEditorManager.h
@@ -154,6 +154,8 @@ public:
 
 	void setElementEnabled(const Id &type, bool enabled) override;
 
+    bool isElementEnabled(const Id &element) override;
+
 	/// Returns list of metamodels for interpreted plugins.
 	QMap<QString, qrRepo::RepoApi*> listOfMetamodels() const;
 

--- a/qrgui/plugins/pluginManager/interpreterEditorManager.h
+++ b/qrgui/plugins/pluginManager/interpreterEditorManager.h
@@ -54,6 +54,7 @@ public:
 	QString unloadPlugin(const QString &pluginName) override;
 
 	QString mouseGesture(const Id &id) const override;
+    QString hotKey(const Id &id) const override;
 	QString friendlyName(const Id &id) const override;
 	QString description(const Id &id) const override;
 	QString propertyDescription(const Id &id, const QString &propertyName) const override;
@@ -126,9 +127,6 @@ public:
 			, const QString &beginType
 			, const QString &endType
 			) const override;
-
-	void updateGenerationRule(const Id &id, const QString &newRule) const override;
-	QString generationRule(const Id &id) const override;
 
 	QPair<Id, Id> createEditorAndDiagram(const QString &name) const override;
 	void saveMetamodel(const QString &newMetamodelFileName) override;

--- a/qrgui/plugins/pluginManager/interpreterEditorManager.h
+++ b/qrgui/plugins/pluginManager/interpreterEditorManager.h
@@ -54,7 +54,7 @@ public:
 	QString unloadPlugin(const QString &pluginName) override;
 
 	QString mouseGesture(const Id &id) const override;
-    QString hotKey(const Id &id) const override;
+	QString hotKey(const Id &id) const override;
 	QString friendlyName(const Id &id) const override;
 	QString description(const Id &id) const override;
 	QString propertyDescription(const Id &id, const QString &propertyName) const override;
@@ -154,7 +154,7 @@ public:
 
 	void setElementEnabled(const Id &type, bool enabled) override;
 
-    bool isElementEnabled(const Id &element) override;
+	bool isElementEnabled(const Id &element) override;
 
 	/// Returns list of metamodels for interpreted plugins.
 	QMap<QString, qrRepo::RepoApi*> listOfMetamodels() const;

--- a/qrgui/plugins/pluginManager/proxyEditorManager.cpp
+++ b/qrgui/plugins/pluginManager/proxyEditorManager.cpp
@@ -411,7 +411,12 @@ void ProxyEditorManager::restoreRenamedProperty(const Id &propertyId, const QStr
 
 void ProxyEditorManager::setElementEnabled(const Id &type, bool enabled)
 {
-	mProxiedEditorManager->setElementEnabled(type, enabled);
+    mProxiedEditorManager->setElementEnabled(type, enabled);
+}
+
+bool ProxyEditorManager::isElementEnabled(const Id &element)
+{
+    return mProxiedEditorManager->isElementEnabled(element);
 }
 
 EditorManagerInterface* ProxyEditorManager::proxiedEditorManager() const

--- a/qrgui/plugins/pluginManager/proxyEditorManager.cpp
+++ b/qrgui/plugins/pluginManager/proxyEditorManager.cpp
@@ -58,7 +58,12 @@ QString ProxyEditorManager::unloadPlugin(const QString &pluginName)
 
 QString ProxyEditorManager::mouseGesture(const Id &id) const
 {
-	return mProxiedEditorManager->mouseGesture(id);
+    return mProxiedEditorManager->mouseGesture(id);
+}
+
+QString ProxyEditorManager::hotKey(const Id &id) const
+{
+    return mProxiedEditorManager->hotKey(id);
 }
 
 QString ProxyEditorManager::friendlyName(const Id &id) const
@@ -311,16 +316,6 @@ void ProxyEditorManager::addEdgeElement(const Id &diagram, const QString &name
 {
 	mProxiedEditorManager->addEdgeElement(diagram, name, displayedName, labelText, labelType
 			, lineType, beginType, endType);
-}
-
-void ProxyEditorManager::updateGenerationRule(const Id &id, const QString &newRule) const
-{
-	mProxiedEditorManager->updateGenerationRule(id, newRule);
-}
-
-QString ProxyEditorManager::generationRule(const Id &id) const
-{
-	return mProxiedEditorManager->generationRule(id);
 }
 
 QPair<Id, Id> ProxyEditorManager::createEditorAndDiagram(const QString &name) const

--- a/qrgui/plugins/pluginManager/proxyEditorManager.cpp
+++ b/qrgui/plugins/pluginManager/proxyEditorManager.cpp
@@ -58,12 +58,12 @@ QString ProxyEditorManager::unloadPlugin(const QString &pluginName)
 
 QString ProxyEditorManager::mouseGesture(const Id &id) const
 {
-    return mProxiedEditorManager->mouseGesture(id);
+	return mProxiedEditorManager->mouseGesture(id);
 }
 
 QString ProxyEditorManager::hotKey(const Id &id) const
 {
-    return mProxiedEditorManager->hotKey(id);
+	return mProxiedEditorManager->hotKey(id);
 }
 
 QString ProxyEditorManager::friendlyName(const Id &id) const
@@ -411,12 +411,12 @@ void ProxyEditorManager::restoreRenamedProperty(const Id &propertyId, const QStr
 
 void ProxyEditorManager::setElementEnabled(const Id &type, bool enabled)
 {
-    mProxiedEditorManager->setElementEnabled(type, enabled);
+	mProxiedEditorManager->setElementEnabled(type, enabled);
 }
 
 bool ProxyEditorManager::isElementEnabled(const Id &element)
 {
-    return mProxiedEditorManager->isElementEnabled(element);
+	return mProxiedEditorManager->isElementEnabled(element);
 }
 
 EditorManagerInterface* ProxyEditorManager::proxiedEditorManager() const

--- a/qrgui/plugins/pluginManager/proxyEditorManager.h
+++ b/qrgui/plugins/pluginManager/proxyEditorManager.h
@@ -52,6 +52,7 @@ public:
 	QString unloadPlugin(const QString &pluginName) override;
 
 	QString mouseGesture(const Id &id) const override;
+    QString hotKey(const Id &id) const override;
 	QString friendlyName(const Id &id) const override;
 	QString description(const Id &id) const override;
 	QString propertyDescription(const Id &id, const QString &propertyName) const override;
@@ -121,9 +122,6 @@ public:
 	void addEdgeElement(const Id &diagram, const QString &name, const QString &displayedName
 			, const QString &labelText, const QString &labelType, const QString &lineType
 			, const QString &beginType, const QString &endType) const override;
-
-	void updateGenerationRule(const Id &id, const QString &newRule) const override;
-	QString generationRule(const Id &id) const override;
 
 	QPair<Id, Id> createEditorAndDiagram(const QString &name) const override;
 	void saveMetamodel(const QString &newMetamodelFileName) override;

--- a/qrgui/plugins/pluginManager/proxyEditorManager.h
+++ b/qrgui/plugins/pluginManager/proxyEditorManager.h
@@ -148,6 +148,8 @@ public:
 
 	void setElementEnabled(const Id &type, bool enabled) override;
 
+    bool isElementEnabled(const Id &element) override;
+
 	/// Returns proxied editor manager.
 	EditorManagerInterface *proxiedEditorManager() const;  // doesn't transfer ownership
 

--- a/qrgui/plugins/pluginManager/proxyEditorManager.h
+++ b/qrgui/plugins/pluginManager/proxyEditorManager.h
@@ -52,7 +52,7 @@ public:
 	QString unloadPlugin(const QString &pluginName) override;
 
 	QString mouseGesture(const Id &id) const override;
-    QString hotKey(const Id &id) const override;
+	QString hotKey(const Id &id) const override;
 	QString friendlyName(const Id &id) const override;
 	QString description(const Id &id) const override;
 	QString propertyDescription(const Id &id, const QString &propertyName) const override;
@@ -148,7 +148,7 @@ public:
 
 	void setElementEnabled(const Id &type, bool enabled) override;
 
-    bool isElementEnabled(const Id &element) override;
+	bool isElementEnabled(const Id &element) override;
 
 	/// Returns proxied editor manager.
 	EditorManagerInterface *proxiedEditorManager() const;  // doesn't transfer ownership

--- a/qrxc/edgeType.cpp
+++ b/qrxc/edgeType.cpp
@@ -473,7 +473,7 @@ void EdgeType::generateEdgeStyle(const QString &styleString, OutFile &out)
 		if (style == "error") {
 			out() << "\t\t\tstatic const QPointF points[] = {"
 					 "\n\t\t\t\tQPointF(-10, 28),\n\t\t\t\tQPointF(-4, 10),"
-					 "\n\t\t\t\tQPointF(3, 20),\n\t\t\t\tQPointF(10, 12),"
+				 "\n\t\t\t\tQPointF(3, 20),\n\t\t\t\tQPointF(10, 12),"
 					 "\n\t\t\t\tQPointF(4, 30),\n\t\t\t\tQPointF(-3, 20),"
 					 "\n\t\t\t\tQPointF(-10, 28)\n\t\t\t};\n"
 					 "\t\t\tpainter->drawPolyline(points, 7);\n";

--- a/qrxc/enumType.cpp
+++ b/qrxc/enumType.cpp
@@ -94,12 +94,12 @@ void EnumType::generatePropertyDefaults(utils::OutFile &out)
 
 void EnumType::generateMouseGesturesMap(utils::OutFile &out)
 {
-    Q_UNUSED(out);
+	Q_UNUSED(out);
 }
 
 void EnumType::generateHotKeyMap(utils::OutFile &out)
 {
-    Q_UNUSED(out);
+	Q_UNUSED(out);
 }
 
 void EnumType::generateExplosionsMap(utils::OutFile &out)

--- a/qrxc/enumType.cpp
+++ b/qrxc/enumType.cpp
@@ -94,7 +94,12 @@ void EnumType::generatePropertyDefaults(utils::OutFile &out)
 
 void EnumType::generateMouseGesturesMap(utils::OutFile &out)
 {
-	Q_UNUSED(out);
+    Q_UNUSED(out);
+}
+
+void EnumType::generateHotKeyMap(utils::OutFile &out)
+{
+    Q_UNUSED(out);
 }
 
 void EnumType::generateExplosionsMap(utils::OutFile &out)

--- a/qrxc/enumType.h
+++ b/qrxc/enumType.h
@@ -29,7 +29,7 @@ public:
 	virtual void generatePropertyTypes(utils::OutFile &out);
 	virtual void generatePropertyDefaults(utils::OutFile &out);
 	virtual void generateMouseGesturesMap(utils::OutFile &out);
-    virtual void generateHotKeyMap(utils::OutFile &out);
+	virtual void generateHotKeyMap(utils::OutFile &out);
 	virtual void generateExplosionsMap(utils::OutFile &out);
 
 	/// Returns true if enum was marked as editable in metamodel.

--- a/qrxc/enumType.h
+++ b/qrxc/enumType.h
@@ -29,6 +29,7 @@ public:
 	virtual void generatePropertyTypes(utils::OutFile &out);
 	virtual void generatePropertyDefaults(utils::OutFile &out);
 	virtual void generateMouseGesturesMap(utils::OutFile &out);
+    virtual void generateHotKeyMap(utils::OutFile &out);
 	virtual void generateExplosionsMap(utils::OutFile &out);
 
 	/// Returns true if enum was marked as editable in metamodel.

--- a/qrxc/graphicType.cpp
+++ b/qrxc/graphicType.cpp
@@ -568,16 +568,16 @@ void GraphicType::generateMouseGesturesMap(OutFile &out)
 			out() << "\"" << pathStr;
 		}
 		out() << "\";\n";
-    }
+	}
 }
 
 void GraphicType::generateHotKeyMap(OutFile &out)
 {
-    QString hotKeyStr = hotKey();
+	QString hotKeyStr = hotKey();
 
-    out() <<  "\tmElementHotKeyMap[\"" << NameNormalizer::normalize(mDiagram->name()) << "\"][\""
-            << NameNormalizer::normalize(qualifiedName()) << "\"] = \"" << hotKeyStr << "\"";
-    out() << ";\n";
+	out() <<  "\tmElementHotKeyMap[\"" << NameNormalizer::normalize(mDiagram->name()) << "\"][\""
+		<< NameNormalizer::normalize(qualifiedName()) << "\"] = \"" << hotKeyStr << "\"";
+	out() << ";\n";
 }
 
 bool GraphicType::generateObjectRequestString(OutFile &out, bool isNotFirst)

--- a/qrxc/graphicType.cpp
+++ b/qrxc/graphicType.cpp
@@ -568,7 +568,16 @@ void GraphicType::generateMouseGesturesMap(OutFile &out)
 			out() << "\"" << pathStr;
 		}
 		out() << "\";\n";
-	}
+    }
+}
+
+void GraphicType::generateHotKeyMap(OutFile &out)
+{
+    QString hotKeyStr = hotKey();
+
+    out() <<  "\tmElementHotKeyMap[\"" << NameNormalizer::normalize(mDiagram->name()) << "\"][\""
+            << NameNormalizer::normalize(qualifiedName()) << "\"] = \"" << hotKeyStr << "\"";
+    out() << ";\n";
 }
 
 bool GraphicType::generateObjectRequestString(OutFile &out, bool isNotFirst)

--- a/qrxc/graphicType.h
+++ b/qrxc/graphicType.h
@@ -48,7 +48,7 @@ public:
 	virtual void generatePropertyTypes(utils::OutFile &out);
 	virtual void generatePropertyDefaults(utils::OutFile &out);
 	virtual void generateMouseGesturesMap(utils::OutFile &out);
-    virtual void generateHotKeyMap(utils::OutFile &out);
+	virtual void generateHotKeyMap(utils::OutFile &out);
 	virtual void generateParentsMapping(utils::OutFile &out);
 	virtual void generateExplosionsMap(utils::OutFile &out);
 	virtual bool copyPorts(NodeType *parent) = 0;

--- a/qrxc/graphicType.h
+++ b/qrxc/graphicType.h
@@ -48,6 +48,7 @@ public:
 	virtual void generatePropertyTypes(utils::OutFile &out);
 	virtual void generatePropertyDefaults(utils::OutFile &out);
 	virtual void generateMouseGesturesMap(utils::OutFile &out);
+    virtual void generateHotKeyMap(utils::OutFile &out);
 	virtual void generateParentsMapping(utils::OutFile &out);
 	virtual void generateExplosionsMap(utils::OutFile &out);
 	virtual bool copyPorts(NodeType *parent) = 0;

--- a/qrxc/nonGraphicType.cpp
+++ b/qrxc/nonGraphicType.cpp
@@ -90,10 +90,10 @@ bool NonGraphicType::generatePossibleEdges(OutFile &out, bool isNotFirst)
 
 void NonGraphicType::generateMouseGesturesMap(utils::OutFile &out)
 {
-    Q_UNUSED(out);
+	Q_UNUSED(out);
 }
 
 void NonGraphicType::generateHotKeyMap(OutFile &out)
 {
-    Q_UNUSED(out);
+	Q_UNUSED(out);
 }

--- a/qrxc/nonGraphicType.cpp
+++ b/qrxc/nonGraphicType.cpp
@@ -90,5 +90,10 @@ bool NonGraphicType::generatePossibleEdges(OutFile &out, bool isNotFirst)
 
 void NonGraphicType::generateMouseGesturesMap(utils::OutFile &out)
 {
-	Q_UNUSED(out);
+    Q_UNUSED(out);
+}
+
+void NonGraphicType::generateHotKeyMap(OutFile &out)
+{
+    Q_UNUSED(out);
 }

--- a/qrxc/nonGraphicType.h
+++ b/qrxc/nonGraphicType.h
@@ -32,7 +32,7 @@ public:
 	virtual bool generateContainedTypes(utils::OutFile &out, bool isNotFirst);
 	virtual bool generatePossibleEdges(utils::OutFile &out, bool isNotFirst);
 	virtual void generateMouseGesturesMap(utils::OutFile &out);
-    virtual void generateHotKeyMap(utils::OutFile &out);
+	virtual void generateHotKeyMap(utils::OutFile &out);
 	virtual void generatePropertyDisplayedNamesMapping(utils::OutFile &out);
 	virtual void generatePropertyDescriptionMapping(utils::OutFile &out);
 	virtual void generateExplosionsMap(utils::OutFile &out);

--- a/qrxc/nonGraphicType.h
+++ b/qrxc/nonGraphicType.h
@@ -32,6 +32,7 @@ public:
 	virtual bool generateContainedTypes(utils::OutFile &out, bool isNotFirst);
 	virtual bool generatePossibleEdges(utils::OutFile &out, bool isNotFirst);
 	virtual void generateMouseGesturesMap(utils::OutFile &out);
+    virtual void generateHotKeyMap(utils::OutFile &out);
 	virtual void generatePropertyDisplayedNamesMapping(utils::OutFile &out);
 	virtual void generatePropertyDescriptionMapping(utils::OutFile &out);
 	virtual void generateExplosionsMap(utils::OutFile &out);

--- a/qrxc/numericType.cpp
+++ b/qrxc/numericType.cpp
@@ -63,7 +63,12 @@ void NumericType::generatePropertyDefaults(utils::OutFile &out)
 
 void NumericType::generateMouseGesturesMap(utils::OutFile &out)
 {
-	Q_UNUSED(out);
+    Q_UNUSED(out);
+}
+
+void NumericType::generateHotkeyMap(utils::OutFile &out)
+{
+    Q_UNUSED(out);
 }
 
 void NumericType::generateExplosionsMap(utils::OutFile &out)

--- a/qrxc/numericType.cpp
+++ b/qrxc/numericType.cpp
@@ -63,12 +63,12 @@ void NumericType::generatePropertyDefaults(utils::OutFile &out)
 
 void NumericType::generateMouseGesturesMap(utils::OutFile &out)
 {
-    Q_UNUSED(out);
+	Q_UNUSED(out);
 }
 
 void NumericType::generateHotkeyMap(utils::OutFile &out)
 {
-    Q_UNUSED(out);
+	Q_UNUSED(out);
 }
 
 void NumericType::generateExplosionsMap(utils::OutFile &out)

--- a/qrxc/numericType.h
+++ b/qrxc/numericType.h
@@ -33,7 +33,7 @@ public:
 	virtual void generatePropertyTypes(utils::OutFile &out);
 	virtual void generatePropertyDefaults(utils::OutFile &out);
 	virtual void generateMouseGesturesMap(utils::OutFile &out);
-    virtual void generateHotkeyMap(utils::OutFile &out);
+	virtual void generateHotkeyMap(utils::OutFile &out);
 	virtual void generateExplosionsMap(utils::OutFile &out);
 
 private:

--- a/qrxc/numericType.h
+++ b/qrxc/numericType.h
@@ -33,6 +33,7 @@ public:
 	virtual void generatePropertyTypes(utils::OutFile &out);
 	virtual void generatePropertyDefaults(utils::OutFile &out);
 	virtual void generateMouseGesturesMap(utils::OutFile &out);
+    virtual void generateHotkeyMap(utils::OutFile &out);
 	virtual void generateExplosionsMap(utils::OutFile &out);
 
 private:

--- a/qrxc/stringType.cpp
+++ b/qrxc/stringType.cpp
@@ -55,7 +55,12 @@ void StringType::generatePropertyDefaults(utils::OutFile &out)
 
 void StringType::generateMouseGesturesMap(utils::OutFile &out)
 {
-	Q_UNUSED(out);
+    Q_UNUSED(out);
+}
+
+void StringType::generateHotKeyMap(utils::OutFile &out)
+{
+    Q_UNUSED(out);
 }
 
 void StringType::generateExplosionsMap(utils::OutFile &out)

--- a/qrxc/stringType.cpp
+++ b/qrxc/stringType.cpp
@@ -55,12 +55,12 @@ void StringType::generatePropertyDefaults(utils::OutFile &out)
 
 void StringType::generateMouseGesturesMap(utils::OutFile &out)
 {
-    Q_UNUSED(out);
+	Q_UNUSED(out);
 }
 
 void StringType::generateHotKeyMap(utils::OutFile &out)
 {
-    Q_UNUSED(out);
+	Q_UNUSED(out);
 }
 
 void StringType::generateExplosionsMap(utils::OutFile &out)

--- a/qrxc/stringType.h
+++ b/qrxc/stringType.h
@@ -27,7 +27,7 @@ public:
 	virtual void generatePropertyTypes(utils::OutFile &out);
 	virtual void generatePropertyDefaults(utils::OutFile &out);
 	virtual void generateMouseGesturesMap(utils::OutFile &out);
-    virtual void generateHotKeyMap(utils::OutFile &out);
+	virtual void generateHotKeyMap(utils::OutFile &out);
 	virtual void generateExplosionsMap(utils::OutFile &out);
 
 private:

--- a/qrxc/stringType.h
+++ b/qrxc/stringType.h
@@ -27,6 +27,7 @@ public:
 	virtual void generatePropertyTypes(utils::OutFile &out);
 	virtual void generatePropertyDefaults(utils::OutFile &out);
 	virtual void generateMouseGesturesMap(utils::OutFile &out);
+    virtual void generateHotKeyMap(utils::OutFile &out);
 	virtual void generateExplosionsMap(utils::OutFile &out);
 
 private:

--- a/qrxc/type.cpp
+++ b/qrxc/type.cpp
@@ -40,7 +40,7 @@ bool Type::init(const QDomElement &element, const QString &context)
 	}
 	mDisplayedName = element.attribute("displayedName", mName);
 	mPath = element.attribute("path", "");
-    mHotKey = element.attribute("hotKey");
+	mHotKey = element.attribute("hotKey");
 	return true;
 }
 
@@ -86,12 +86,12 @@ void Type::setName(const QString &name)
 
 QString Type::displayedName() const
 {
-    return mDisplayedName;
+	return mDisplayedName;
 }
 
 QString Type::hotKey() const
 {
-    return mHotKey;
+	return mHotKey;
 }
 
 void Type::setDisplayedName(const QString &displayedName)

--- a/qrxc/type.cpp
+++ b/qrxc/type.cpp
@@ -40,6 +40,7 @@ bool Type::init(const QDomElement &element, const QString &context)
 	}
 	mDisplayedName = element.attribute("displayedName", mName);
 	mPath = element.attribute("path", "");
+    mHotKey = element.attribute("hotKey");
 	return true;
 }
 
@@ -85,7 +86,12 @@ void Type::setName(const QString &name)
 
 QString Type::displayedName() const
 {
-	return mDisplayedName;
+    return mDisplayedName;
+}
+
+QString Type::hotKey() const
+{
+    return mHotKey;
 }
 
 void Type::setDisplayedName(const QString &displayedName)

--- a/qrxc/type.h
+++ b/qrxc/type.h
@@ -39,7 +39,7 @@ public:
 	QString path() const;
 	QString qualifiedName() const;
 	QString displayedName() const;
-    QString hotKey() const;
+	QString hotKey() const;
 
 	QMap<QString, Property*> properties() const;
 
@@ -59,7 +59,7 @@ public:
 	virtual void generatePropertyDefaults(utils::OutFile &out) = 0;
 	virtual void generatePropertyDescriptionMapping(utils::OutFile &out) = 0;
 	virtual void generateMouseGesturesMap(utils::OutFile &out) = 0;
-    virtual void generateHotKeyMap(utils::OutFile &out) = 0;
+	virtual void generateHotKeyMap(utils::OutFile &out) = 0;
 	virtual void generateExplosionsMap(utils::OutFile &out) = 0;
 
 protected:
@@ -79,5 +79,5 @@ private:
 	QString mNativeContext;
 	QString mDisplayedName;
 	QString mPath;
-    QString mHotKey;
+	QString mHotKey;
 };

--- a/qrxc/type.h
+++ b/qrxc/type.h
@@ -39,6 +39,7 @@ public:
 	QString path() const;
 	QString qualifiedName() const;
 	QString displayedName() const;
+    QString hotKey() const;
 
 	QMap<QString, Property*> properties() const;
 
@@ -58,6 +59,7 @@ public:
 	virtual void generatePropertyDefaults(utils::OutFile &out) = 0;
 	virtual void generatePropertyDescriptionMapping(utils::OutFile &out) = 0;
 	virtual void generateMouseGesturesMap(utils::OutFile &out) = 0;
+    virtual void generateHotKeyMap(utils::OutFile &out) = 0;
 	virtual void generateExplosionsMap(utils::OutFile &out) = 0;
 
 protected:
@@ -77,4 +79,5 @@ private:
 	QString mNativeContext;
 	QString mDisplayedName;
 	QString mPath;
+    QString mHotKey;
 };

--- a/qrxc/xmlCompiler.cpp
+++ b/qrxc/xmlCompiler.cpp
@@ -218,6 +218,7 @@ void XmlCompiler::generatePluginHeader()
 		<< "\tQString propertyDisplayedName(const QString &diagram, const QString &element, const QString "
 				"&property) const override;\n"
 		<< "\tQString elementMouseGesture(const QString &digram, const QString &element) const override;\n"
+           "\tQString elementHotKey(const QString &diagram, const QString &element) const override;\n"
 		<< "\n"
 		<< "\tQList<qReal::ListenerInterface*> listeners() const override;\n"
 		<< "\n"
@@ -232,6 +233,7 @@ void XmlCompiler::generatePluginHeader()
 		<< "private:\n"
 		<< "\tvirtual void initPlugin();\n"
 		<< "\tvirtual void initMouseGestureMap();\n"
+        << "\tvirtual void initHotKeyMap();\n"
 		<< "\tvirtual void initNameMap();\n"
 		<< "\tvirtual void initPropertyMap();\n"
 		<< "\tvirtual void initPropertyDefaultsMap();\n"
@@ -252,6 +254,7 @@ void XmlCompiler::generatePluginHeader()
 		<< "\tQMap<QString, QMap<QString, QMap<QString, QString>>> mPropertiesDescriptionMap;\n"
 		<< "\tQMap<QString, QMap<QString, QMap<QString, QString>>> mPropertiesDisplayedNamesMap;\n"
 		<< "\tQMap<QString, QMap<QString, QString>> mElementMouseGesturesMap;\n"
+        << "\tQMap<QString, QMap<QString, QString>> mElementHotKeyMap;\n"
 		<< "\tQMap<QString, QMap<QString, QList<QPair<QString, QString>>>> mParentsMap;  // Maps diagram and element"
 				" to a list of diagram-element pairs of parents (generalization relation).\n"
 		<< "\tQMap<QString, QList<QPair<QString, QStringList>>> mPaletteGroupsMap;  // Maps element`s lists of all "
@@ -313,6 +316,7 @@ void XmlCompiler::generateInitPlugin(OutFile &out)
 	out() << "void " << mPluginName << "Plugin::initPlugin()\n{\n"
 		<< "\tinitNameMap();\n"
 		<< "\tinitMouseGestureMap();\n"
+        << "\tinitHotKeyMap();\n"
 		<< "\tinitPropertyMap();\n"
 		<< "\tinitPropertyDefaultsMap();\n"
 		<< "\tinitDescriptionMap();\n"
@@ -327,6 +331,7 @@ void XmlCompiler::generateInitPlugin(OutFile &out)
 	generatePaletteGroupsLists(out);
 	generatePaletteGroupsDescriptions(out);
 	generateMouseGestureMap(out);
+    generateHotKeyMap(out);
 	generatePropertyMap(out);
 	generatePropertyDefaultsMap(out);
 	generateDescriptionMappings(out);
@@ -471,7 +476,18 @@ void XmlCompiler::generateMouseGestureMap(OutFile &out)
 			type->generateMouseGesturesMap(out);
 		}
 	}
-	out() << "}\n\n";
+    out() << "}\n\n";
+}
+
+void XmlCompiler::generateHotKeyMap(OutFile &out)
+{
+    out() << "void " << mPluginName << "Plugin::initHotKeyMap()\n{\n";
+    foreach (Diagram *diagram, mEditors[mCurrentEditor]->diagrams().values()) {
+        foreach (Type *type, diagram->types().values()) {
+            type->generateHotKeyMap(out);
+        }
+    }
+    out() << "}\n\n";
 }
 
 void XmlCompiler::generatePropertyMap(OutFile &out)
@@ -604,6 +620,11 @@ void XmlCompiler::generateNameMappingsRequests(OutFile &out)
 		<< "const\n{\n"
 		<< "\treturn mElementMouseGesturesMap[diagram][element];\n"
 		<< "}\n\n"
+
+        << "QString " << mPluginName << "Plugin::elementHotKey(const QString &diagram, const QString &element) "
+        << "const\n{\n"
+        << "\treturn mElementHotKeyMap[diagram][element];\n"
+        << "}\n\n"
 
 		<< "QList<qReal::EditorInterface::ExplosionData>" << mPluginName
 				<< "Plugin::explosions(const QString &diagram, "

--- a/qrxc/xmlCompiler.cpp
+++ b/qrxc/xmlCompiler.cpp
@@ -218,7 +218,7 @@ void XmlCompiler::generatePluginHeader()
 		<< "\tQString propertyDisplayedName(const QString &diagram, const QString &element, const QString "
 				"&property) const override;\n"
 		<< "\tQString elementMouseGesture(const QString &digram, const QString &element) const override;\n"
-           "\tQString elementHotKey(const QString &diagram, const QString &element) const override;\n"
+			"\tQString elementHotKey(const QString &diagram, const QString &element) const override;\n"
 		<< "\n"
 		<< "\tQList<qReal::ListenerInterface*> listeners() const override;\n"
 		<< "\n"
@@ -233,7 +233,7 @@ void XmlCompiler::generatePluginHeader()
 		<< "private:\n"
 		<< "\tvirtual void initPlugin();\n"
 		<< "\tvirtual void initMouseGestureMap();\n"
-        << "\tvirtual void initHotKeyMap();\n"
+		<< "\tvirtual void initHotKeyMap();\n"
 		<< "\tvirtual void initNameMap();\n"
 		<< "\tvirtual void initPropertyMap();\n"
 		<< "\tvirtual void initPropertyDefaultsMap();\n"
@@ -254,7 +254,7 @@ void XmlCompiler::generatePluginHeader()
 		<< "\tQMap<QString, QMap<QString, QMap<QString, QString>>> mPropertiesDescriptionMap;\n"
 		<< "\tQMap<QString, QMap<QString, QMap<QString, QString>>> mPropertiesDisplayedNamesMap;\n"
 		<< "\tQMap<QString, QMap<QString, QString>> mElementMouseGesturesMap;\n"
-        << "\tQMap<QString, QMap<QString, QString>> mElementHotKeyMap;\n"
+		<< "\tQMap<QString, QMap<QString, QString>> mElementHotKeyMap;\n"
 		<< "\tQMap<QString, QMap<QString, QList<QPair<QString, QString>>>> mParentsMap;  // Maps diagram and element"
 				" to a list of diagram-element pairs of parents (generalization relation).\n"
 		<< "\tQMap<QString, QList<QPair<QString, QStringList>>> mPaletteGroupsMap;  // Maps element`s lists of all "
@@ -316,7 +316,7 @@ void XmlCompiler::generateInitPlugin(OutFile &out)
 	out() << "void " << mPluginName << "Plugin::initPlugin()\n{\n"
 		<< "\tinitNameMap();\n"
 		<< "\tinitMouseGestureMap();\n"
-        << "\tinitHotKeyMap();\n"
+		<< "\tinitHotKeyMap();\n"
 		<< "\tinitPropertyMap();\n"
 		<< "\tinitPropertyDefaultsMap();\n"
 		<< "\tinitDescriptionMap();\n"
@@ -331,7 +331,7 @@ void XmlCompiler::generateInitPlugin(OutFile &out)
 	generatePaletteGroupsLists(out);
 	generatePaletteGroupsDescriptions(out);
 	generateMouseGestureMap(out);
-    generateHotKeyMap(out);
+	generateHotKeyMap(out);
 	generatePropertyMap(out);
 	generatePropertyDefaultsMap(out);
 	generateDescriptionMappings(out);
@@ -476,18 +476,18 @@ void XmlCompiler::generateMouseGestureMap(OutFile &out)
 			type->generateMouseGesturesMap(out);
 		}
 	}
-    out() << "}\n\n";
+	out() << "}\n\n";
 }
 
 void XmlCompiler::generateHotKeyMap(OutFile &out)
 {
-    out() << "void " << mPluginName << "Plugin::initHotKeyMap()\n{\n";
-    foreach (Diagram *diagram, mEditors[mCurrentEditor]->diagrams().values()) {
-        foreach (Type *type, diagram->types().values()) {
-            type->generateHotKeyMap(out);
-        }
-    }
-    out() << "}\n\n";
+	out() << "void " << mPluginName << "Plugin::initHotKeyMap()\n{\n";
+	foreach (Diagram *diagram, mEditors[mCurrentEditor]->diagrams().values()) {
+		foreach (Type *type, diagram->types().values()) {
+			type->generateHotKeyMap(out);
+		}
+	}
+	out() << "}\n\n";
 }
 
 void XmlCompiler::generatePropertyMap(OutFile &out)
@@ -621,10 +621,10 @@ void XmlCompiler::generateNameMappingsRequests(OutFile &out)
 		<< "\treturn mElementMouseGesturesMap[diagram][element];\n"
 		<< "}\n\n"
 
-        << "QString " << mPluginName << "Plugin::elementHotKey(const QString &diagram, const QString &element) "
-        << "const\n{\n"
-        << "\treturn mElementHotKeyMap[diagram][element];\n"
-        << "}\n\n"
+		<< "QString " << mPluginName << "Plugin::elementHotKey(const QString &diagram, const QString &element) "
+		<< "const\n{\n"
+		<< "\treturn mElementHotKeyMap[diagram][element];\n"
+		<< "}\n\n"
 
 		<< "QList<qReal::EditorInterface::ExplosionData>" << mPluginName
 				<< "Plugin::explosions(const QString &diagram, "

--- a/qrxc/xmlCompiler.h
+++ b/qrxc/xmlCompiler.h
@@ -44,6 +44,7 @@ private:
 	void generateInitPlugin(utils::OutFile &out);
 	void generateNameMappings(utils::OutFile &out);
 	void generateMouseGestureMap(utils::OutFile &out);
+    void generateHotKeyMap(utils::OutFile &out);
 	void generatePropertyMap(utils::OutFile &out);
 	void generatePropertyDefaultsMap(utils::OutFile &out);
 	void generateDescriptionMappings(utils::OutFile &out);

--- a/qrxc/xmlCompiler.h
+++ b/qrxc/xmlCompiler.h
@@ -44,7 +44,7 @@ private:
 	void generateInitPlugin(utils::OutFile &out);
 	void generateNameMappings(utils::OutFile &out);
 	void generateMouseGestureMap(utils::OutFile &out);
-    void generateHotKeyMap(utils::OutFile &out);
+	void generateHotKeyMap(utils::OutFile &out);
 	void generatePropertyMap(utils::OutFile &out);
 	void generatePropertyDefaultsMap(utils::OutFile &out);
 	void generateDescriptionMappings(utils::OutFile &out);


### PR DESCRIPTION
Hotkeys for elements are read from corresponding metamodel XML. Currently do not care for hotkey conflicts.