### PR TITLE
Devices state reporting in checker

### DIFF
--- a/plugins/robots/checker/twoDModelRunner/reporter.h
+++ b/plugins/robots/checker/twoDModelRunner/reporter.h
@@ -58,13 +58,29 @@ public slots:
 	void addError(const QString &message);
 
 	/// Writes an information abount the new trajectory point into the given in constructor file.
+	/// @param robotId The id of the moved robot.
+	/// @param timestamp Count of milliseconds passed from the interpretation start when the event happened.
+	/// @param timestamp The position of the robot in scene coordinates.
+	/// @param rotation The rotation angle of the robot in degrees.
 	void newTrajectoryPoint(const QString &robotId, int timestamp, const QPointF &position, qreal rotation);
+
+	/// Writes JSON object representing modification of some robot`s device property into the trajectory stream.
+	/// @param robotId The id of the robot owning the device.
+	/// @param timestamp Count of milliseconds passed from the interpretation start when the event happened.
+	/// @param deviceType The type name of the device obtained by DeviceInfo::name().
+	/// @param devicePort The name of the port the device is plugged into, obtained by PortInfo::name().
+	/// @param property The name of the modified Q_PROPERTY.
+	/// @param value The new value of the property.
+	void newDeviceState(const QString &robotId, int timestamp, const QString &deviceType
+			, const QString &devicePort, const QString &property, const QVariant &value);
 
 	/// Writes an information about all messages shown to user during the interpretation process into the specified
 	/// in constructor file in XML format.
 	void reportMessages();
 
 private:
+	QJsonValue variantToJson(const QVariant &value) const;
+
 	QList<QPair<Level, QString>> mMessages;
 	const QScopedPointer<utils::OutFile> mMessagesFile;
 	const QScopedPointer<utils::OutFile> mTrajectoryFile;

--- a/plugins/robots/checker/twoDModelRunner/reporter.h
+++ b/plugins/robots/checker/twoDModelRunner/reporter.h
@@ -57,6 +57,12 @@ public slots:
 	/// Reports the error message reported to user during the interpretation process.
 	void addError(const QString &message);
 
+	/// Resets inner state for new interpretation instance.
+	void onInterpretationStart();
+
+	/// Finalizes reports when interpretation has finished.
+	void onInterpretationEnd();
+
 	/// Writes an information abount the new trajectory point into the given in constructor file.
 	/// @param robotId The id of the moved robot.
 	/// @param timestamp Count of milliseconds passed from the interpretation start when the event happened.
@@ -80,10 +86,12 @@ public slots:
 
 private:
 	QJsonValue variantToJson(const QVariant &value) const;
+	void report(const QString &message, const QScopedPointer<utils::OutFile> &file);
 
 	QList<QPair<Level, QString>> mMessages;
 	const QScopedPointer<utils::OutFile> mMessagesFile;
 	const QScopedPointer<utils::OutFile> mTrajectoryFile;
+	bool mFirstMessage;
 };
 
 }

--- a/plugins/robots/checker/twoDModelRunner/runner.cpp
+++ b/plugins/robots/checker/twoDModelRunner/runner.cpp
@@ -48,6 +48,7 @@ Runner::Runner(const QString &report, const QString &trajectory)
 
 Runner::~Runner()
 {
+	mReporter.onInterpretationEnd();
 	mReporter.reportMessages();
 }
 
@@ -82,6 +83,7 @@ void Runner::interpret(const QString &saveFile, bool background)
 		}
 	}
 
+	mReporter.onInterpretationStart();
 	mPluginFacade.actionsManager().runAction().trigger();
 }
 

--- a/plugins/robots/checker/twoDModelRunner/runner.cpp
+++ b/plugins/robots/checker/twoDModelRunner/runner.cpp
@@ -77,13 +77,26 @@ void Runner::interpret(const QString &saveFile, bool background)
 	for (view::TwoDModelWidget * const  twoDModelWindow : twoDModelWindows) {
 		connect(twoDModelWindow, &view::TwoDModelWidget::widgetClosed, [=]() { mMainWindow.emulateClose(); });
 		twoDModelWindow->model().timeline().setImmediateMode(background);
-		for (model::RobotModel *robotModel : twoDModelWindow->model().robotModels()) {
-			connect(robotModel, &model::RobotModel::positionRecalculated
-					, this, &Runner::onRobotRided, Qt::UniqueConnection);
+		for (const model::RobotModel *robotModel : twoDModelWindow->model().robotModels()) {
+			connectRobotModel(robotModel);
 		}
 	}
 
 	mPluginFacade.actionsManager().runAction().trigger();
+}
+
+void Runner::connectRobotModel(const model::RobotModel *robotModel)
+{
+	connect(robotModel, &model::RobotModel::positionRecalculated
+			, this, &Runner::onRobotRided, Qt::UniqueConnection);
+
+	connect(&robotModel->info().configuration(), &kitBase::robotModel::ConfigurationInterface::deviceConfigured
+			, this, [=](const kitBase::robotModel::robotParts::Device *device) {
+		connect(device, &kitBase::robotModel::robotParts::Device::propertyChanged, this
+				, [=](const QString &property, const QVariant &value) {
+			onDeviceStateChanged(robotModel->info().robotId(), device, property, value);
+		});
+	});
 }
 
 void Runner::onRobotRided(const QPointF &newPosition, const qreal newRotation)
@@ -93,5 +106,19 @@ void Runner::onRobotRided(const QPointF &newPosition, const qreal newRotation)
 			, mPluginFacade.interpreter().timeElapsed()
 			, newPosition
 			, newRotation
-	);
+			);
+}
+
+void Runner::onDeviceStateChanged(const QString &robotId
+		, const kitBase::robotModel::robotParts::Device *device
+		, const QString &property
+		, const QVariant &value)
+{
+	mReporter.newDeviceState(robotId
+			, mPluginFacade.interpreter().timeElapsed()
+			, device->deviceInfo().name()
+			, device->port().name()
+			, property
+			, value
+			);
 }

--- a/plugins/robots/checker/twoDModelRunner/runner.h
+++ b/plugins/robots/checker/twoDModelRunner/runner.h
@@ -26,6 +26,10 @@
 
 namespace twoDModel {
 
+namespace model {
+class RobotModel;
+}
+
 /// Creates instances null QReal environment, of robots plugin and runs interpretation on 2D model window.
 class Runner : public QObject
 {
@@ -45,7 +49,10 @@ public:
 	void interpret(const QString &saveFile, bool background);
 
 private:
+	void connectRobotModel(const model::RobotModel *robotModel);
 	void onRobotRided(const QPointF &newPosition, const qreal newRotation);
+	void onDeviceStateChanged(const QString &robotId, const kitBase::robotModel::robotParts::Device *device
+			, const QString &property, const QVariant &value);
 
 	qReal::SystemFacade mQRealFacade;
 	qReal::ConsoleErrorReporter mErrorReporter;

--- a/plugins/robots/common/kitBase/include/kitBase/robotModel/robotParts/device.h
+++ b/plugins/robots/common/kitBase/include/kitBase/robotModel/robotParts/device.h
@@ -61,6 +61,10 @@ signals:
 	/// performed by Device class.
 	void configured(bool success);
 
+	/// Emitted when of the value of device`s \a property has changed to \a value.
+	/// The device itself may notify other components about its inner state via this signal.
+	void propertyChanged(const QString &property, const QVariant &value);
+
 protected:
 	/// Perform actual configuration of a device. Shall be implemented for concrete devices with non-trivial
 	/// configuration logic default implementation tells that device is already configured.

--- a/plugins/robots/common/kitBase/src/blocksBase/common/waitForButtonBlock.cpp
+++ b/plugins/robots/common/kitBase/src/blocksBase/common/waitForButtonBlock.cpp
@@ -39,20 +39,14 @@ void WaitForButtonBlock::run()
 	}
 
 	connect(mButton, &robotModel::robotParts::Button::newData, this, &WaitForButtonBlock::responseSlot);
-	if (mButton->port().reservedVariable().isEmpty()) {
-		// Buttons with non-empty reserved variables will be updated in background themselves.
-		mButton->read();
-	}
 
+	mButton->read();
 	mActiveWaitingTimer->start();
 }
 
 void WaitForButtonBlock::timerTimeout()
 {
-	if (mButton->port().reservedVariable().isEmpty()) {
-		// Buttons with non-empty reserved variables will be updated in background themselves.
-		mButton->read();
-	}
+	mButton->read();
 }
 
 void WaitForButtonBlock::responseSlot(int isPressed)

--- a/plugins/robots/common/kitBase/src/blocksBase/common/waitForSensorBlock.cpp
+++ b/plugins/robots/common/kitBase/src/blocksBase/common/waitForSensorBlock.cpp
@@ -39,10 +39,7 @@ void WaitForSensorBlock::run()
 		connect(sensor, &robotParts::ScalarSensor::newData, this, &WaitForSensorBlock::responseSlot);
 		connect(sensor, &robotParts::AbstractSensor::failure, this, &WaitForSensorBlock::failureSlot);
 		mActiveWaitingTimer->start();
-		if (sensor->port().reservedVariable().isEmpty()) {
-			// Sensors with non-empty reserved variables will be updated in background themselves.
-			sensor->read();
-		}
+		sensor->read();
 	} else {
 		mActiveWaitingTimer->stop();
 		error(tr("%1 is not configured on port %2").arg(device().friendlyName(), mPort.userFriendlyName()));
@@ -53,9 +50,8 @@ void WaitForSensorBlock::timerTimeout()
 {
 	/// @todo True horror.
 	robotParts::Device * const device = mRobotModel.configuration().device(mPort);
-	robotParts::ScalarSensor *sensor = dynamic_cast<robotParts::ScalarSensor *>(device);
-	if (sensor && sensor->port().reservedVariable().isEmpty()) {
-		// Sensors with non-empty reserved variables will be updated in background themselves.
+	robotParts::ScalarSensor * const sensor = dynamic_cast<robotParts::ScalarSensor *>(device);
+	if (sensor) {
 		sensor->read();
 	}
 }

--- a/plugins/robots/common/trikKit/src/blocks/details/waitGamepadButtonBlock.cpp
+++ b/plugins/robots/common/trikKit/src/blocks/details/waitGamepadButtonBlock.cpp
@@ -43,20 +43,14 @@ void WaitGamepadButtonBlock::run()
 	}
 
 	connect(mButton, &robotModel::parts::TrikGamepadButton::newData, this, &WaitGamepadButtonBlock::responseSlot);
-	if (mButton->port().reservedVariable().isEmpty()) {
-		// Buttons with non-empty reserved variables will be updated in background themselves.
-		mButton->read();
-	}
 
+	mButton->read();
 	mActiveWaitingTimer->start();
 }
 
 void WaitGamepadButtonBlock::timerTimeout()
 {
-	if (mButton->port().reservedVariable().isEmpty()) {
-		// Buttons with non-empty reserved variables will be updated in background themselves.
-		mButton->read();
-	}
+	mButton->read();
 }
 
 void WaitGamepadButtonBlock::responseSlot(int isPressed)

--- a/plugins/robots/common/twoDModel/include/twoDModel/engine/model/robotModel.h
+++ b/plugins/robots/common/twoDModel/include/twoDModel/engine/model/robotModel.h
@@ -71,7 +71,7 @@ public:
 	SensorsConfiguration &configuration();
 
 	/// Returns a reference to external robot description.
-	robotModel::TwoDRobotModel &info();
+	robotModel::TwoDRobotModel &info() const;
 
 	int readEncoder(const kitBase::robotModel::PortInfo &port) const;
 	void resetEncoder(const kitBase::robotModel::PortInfo &port);

--- a/plugins/robots/common/twoDModel/include/twoDModel/robotModel/parts/marker.h
+++ b/plugins/robots/common/twoDModel/include/twoDModel/robotModel/parts/marker.h
@@ -35,7 +35,7 @@ class TWO_D_MODEL_EXPORT Marker : public kitBase::robotModel::robotParts::Device
 	Q_CLASSINFO("direction", "output")
 	Q_CLASSINFO("name", "marker")
 	Q_CLASSINFO("friendlyName", tr("Marker"))
-	Q_PROPERTY(bool isDown READ isDown WRITE setDown)
+	Q_PROPERTY(bool isDown READ isDown WRITE setDown NOTIFY isDownChanged)
 
 public:
 	Marker(const kitBase::robotModel::DeviceInfo &info
@@ -56,6 +56,13 @@ public:
 
 	/// Calls down() with black color if \a isDown is true or up() otherwise.
 	void setDown(bool isDown);
+
+signals:
+	/// Emitted with 'true' parameter when marker activated and 'false' when it was lifted.
+	void isDownChanged(bool isDown);
+
+	/// Emitted when marker color has changed.
+	void colorChanged(const QColor &color);
 
 private:
 	engine::TwoDModelEngineInterface &mEngine;

--- a/plugins/robots/common/twoDModel/src/engine/model/robotModel.cpp
+++ b/plugins/robots/common/twoDModel/src/engine/model/robotModel.cpp
@@ -161,7 +161,7 @@ SensorsConfiguration &RobotModel::configuration()
 	return mSensorsConfiguration;
 }
 
-twoDModel::robotModel::TwoDRobotModel &RobotModel::info()
+twoDModel::robotModel::TwoDRobotModel &RobotModel::info() const
 {
 	return mRobotModel;
 }

--- a/plugins/robots/common/twoDModel/src/engine/view/scene/twoDModelScene.cpp
+++ b/plugins/robots/common/twoDModel/src/engine/view/scene/twoDModelScene.cpp
@@ -387,14 +387,15 @@ void TwoDModelScene::keyPressEvent(QKeyEvent *event)
 {
 	if (event->key() == Qt::Key_Delete && (selectedItems().size() > 0)) {
 		for (QGraphicsItem * const item : selectedItems()) {
-			auto worldItem = dynamic_cast<items::ColorFieldItem *>(item);
-			auto robotItem = dynamic_cast<RobotItem *>(item);
-			auto sensorItem = dynamic_cast<SensorItem *>(item);
-			if (worldItem && mWorldReadOnly) {
+			const bool isWorldItem = dynamic_cast<items::ColorFieldItem *>(item)
+					|| dynamic_cast<items::WallItem *>(item);
+			const bool isRobotItem = dynamic_cast<RobotItem *>(item) != nullptr;
+			const bool isSensorItem = dynamic_cast<SensorItem *>(item) != nullptr;
+			if (isWorldItem && mWorldReadOnly) {
 				return;
-			} else if (robotItem && mRobotReadOnly) {
+			} else if (isRobotItem && mRobotReadOnly) {
 				return;
-			} else if (sensorItem && mSensorsReadOnly) {
+			} else if (isSensorItem && mSensorsReadOnly) {
 				return;
 			}
 

--- a/plugins/robots/common/twoDModel/src/robotModel/parts/marker.cpp
+++ b/plugins/robots/common/twoDModel/src/robotModel/parts/marker.cpp
@@ -26,16 +26,21 @@ Marker::Marker(const kitBase::robotModel::DeviceInfo &info
 	: Device(info, port)
 	, mEngine(engine)
 {
+	connect(this, &Marker::isDownChanged, this, [=](bool isDown) { emit propertyChanged("isDown", isDown); });
+	connect(this, &Marker::colorChanged, this, [=](const QColor &color) { emit propertyChanged("color", color); });
 }
 
 void Marker::down(const QColor &color)
 {
 	mEngine.markerDown(color);
+	emit isDownChanged(true);
+	emit colorChanged(color);
 }
 
 void Marker::up()
 {
 	mEngine.markerUp();
+	emit isDownChanged(false);
 }
 
 bool Marker::isDown() const

--- a/plugins/robots/interpreters/trikKitInterpreterCommon/include/trikKitInterpreterCommon/robotModel/twoD/parts/twoDDisplay.h
+++ b/plugins/robots/interpreters/trikKitInterpreterCommon/include/trikKitInterpreterCommon/robotModel/twoD/parts/twoDDisplay.h
@@ -32,16 +32,16 @@ class ROBOTS_TRIK_KIT_INTERPRETER_COMMON_EXPORT Display : public robotModel::par
 {
 	Q_OBJECT
 	// Canvas cannot be QObject because of ambiguous base so we are forced to copy properties here.
-	Q_PROPERTY(QList<utils::CanvasObject *> objects READ objects)
-	Q_PROPERTY(QList<utils::PointObject *> pixels READ pixels)
-	Q_PROPERTY(QList<utils::LineObject *> segments READ segments)
-	Q_PROPERTY(QList<utils::RectangleObject *> rectangles READ rectangles)
-	Q_PROPERTY(QList<utils::EllipseObject *> ellipses READ ellipses)
-	Q_PROPERTY(QList<utils::ArcObject *> arcs READ arcs)
-	Q_PROPERTY(QList<utils::TextObject *> labels READ labels)
-	Q_PROPERTY(QString background READ background WRITE setBackground)
-	Q_PROPERTY(bool smiles READ smiles)
-	Q_PROPERTY(bool sadSmiles READ sadSmiles)
+	Q_PROPERTY(QList<utils::CanvasObject *> objects READ objects NOTIFY shapesSetChanged)
+	Q_PROPERTY(QList<utils::PointObject *> pixels READ pixels NOTIFY shapesSetChanged)
+	Q_PROPERTY(QList<utils::LineObject *> segments READ segments NOTIFY shapesSetChanged)
+	Q_PROPERTY(QList<utils::RectangleObject *> rectangles READ rectangles NOTIFY shapesSetChanged)
+	Q_PROPERTY(QList<utils::EllipseObject *> ellipses READ ellipses NOTIFY shapesSetChanged)
+	Q_PROPERTY(QList<utils::ArcObject *> arcs READ arcs NOTIFY shapesSetChanged)
+	Q_PROPERTY(QList<utils::TextObject *> labels READ labels NOTIFY shapesSetChanged)
+	Q_PROPERTY(QString background READ background WRITE setBackground NOTIFY backgroundChanged)
+	Q_PROPERTY(bool smiles READ smiles NOTIFY smileChanged)
+	Q_PROPERTY(bool sadSmiles READ sadSmiles NOTIFY smileChanged)
 
 public:
 	Display(const kitBase::robotModel::DeviceInfo &info
@@ -71,6 +71,20 @@ public:
 	void paint(QPainter *painter) override;
 	void reset() override;
 	void redraw() override;
+
+signals:
+	/// Emitted when bacground color has changed.
+	/// @param color The current (new) color of the background, may be transparent.
+	void backgroundChanged(const QColor &color);
+
+	/// Emitted when smile appeared or disappeared on the robot`s screen.
+	/// @param smiles If true then some smile (sad or happy) is currently drawn on the screen.
+	/// If false -- there is no smile currently drawn.
+	/// @param happy False if sad smile is drawn, true if happy. If \a smiles argument is false then value is undefined.
+	void smileChanged(bool smiles, bool happy);
+
+	/// Emitted when new shape (ellipse, line, pencil, etc.) appeared or disappeared on the robot`s screen.
+	void shapesSetChanged();
 
 private:
 	twoDModel::engine::TwoDModelEngineInterface &mEngine;

--- a/plugins/robots/interpreters/trikKitInterpreterCommon/include/trikKitInterpreterCommon/robotModel/twoD/parts/twoDLed.h
+++ b/plugins/robots/interpreters/trikKitInterpreterCommon/include/trikKitInterpreterCommon/robotModel/twoD/parts/twoDLed.h
@@ -29,7 +29,7 @@ namespace parts {
 class ROBOTS_TRIK_KIT_INTERPRETER_COMMON_EXPORT TwoDLed : public robotModel::parts::TrikLed
 {
 	Q_OBJECT
-	Q_PROPERTY(QColor color READ color WRITE setColor)
+	Q_PROPERTY(QColor color READ color WRITE setColor NOTIFY colorChanged)
 
 public:
 	TwoDLed(const kitBase::robotModel::DeviceInfo &info
@@ -45,6 +45,12 @@ public:
 	/// Sets the \a color of led emulator in 2D model.
 	/// If "off" passed then led becomes gray.
 	void setColor(const QString &color) override;
+
+signals:
+	/// Emitted when led color has changed.
+	/// @warning This signal will not be emitted on led color chage right before or right after the interpretation.
+	/// It notifies only about led`s color modification by led block.
+	void colorChanged(const QColor &color);
 
 private:
 	twoDModel::engine::TwoDModelEngineInterface &mEngine;

--- a/plugins/robots/interpreters/trikKitInterpreterCommon/include/trikKitInterpreterCommon/robotModel/twoD/parts/twoDShell.h
+++ b/plugins/robots/interpreters/trikKitInterpreterCommon/include/trikKitInterpreterCommon/robotModel/twoD/parts/twoDShell.h
@@ -37,7 +37,7 @@ namespace parts {
 class ROBOTS_TRIK_KIT_INTERPRETER_COMMON_EXPORT Shell : public robotModel::parts::TrikShell
 {
 	Q_OBJECT
-	Q_PROPERTY(QString lastPhrase READ lastPhrase WRITE say)
+	Q_PROPERTY(QString lastPhrase READ lastPhrase WRITE say NOTIFY phraseTold)
 
 public:
 	Shell(const kitBase::robotModel::DeviceInfo &info
@@ -59,6 +59,10 @@ public:
 
 	/// Resets shell instance preparing it to new interpretation time.
 	void reset();
+
+signals:
+	/// Emitted when robot starts speaking some phrase; the told text is passed as argument.
+	void phraseTold(const QString &text);
 
 private:
 	twoDModel::engine::TwoDModelEngineInterface &mEngine;

--- a/plugins/robots/interpreters/trikKitInterpreterCommon/src/robotModel/twoD/parts/twoDLed.cpp
+++ b/plugins/robots/interpreters/trikKitInterpreterCommon/src/robotModel/twoD/parts/twoDLed.cpp
@@ -25,6 +25,7 @@ TwoDLed::TwoDLed(const DeviceInfo &info
 	: robotModel::parts::TrikLed(info, port)
 	, mEngine(engine)
 {
+	connect(this, &TwoDLed::colorChanged, this, [=](const QColor &color) { emit propertyChanged("color", color); });
 }
 
 QColor TwoDLed::color() const
@@ -39,6 +40,7 @@ void TwoDLed::setColor(const QColor &color)
 	auto display = dynamic_cast<TrikDisplayWidget *>(mEngine.display());
 	Q_ASSERT(display);
 	display->setLedColor(color);
+	emit colorChanged(color);
 }
 
 void TwoDLed::setColor(const QString &color)

--- a/plugins/robots/interpreters/trikKitInterpreterCommon/src/robotModel/twoD/parts/twoDShell.cpp
+++ b/plugins/robots/interpreters/trikKitInterpreterCommon/src/robotModel/twoD/parts/twoDShell.cpp
@@ -29,6 +29,7 @@ Shell::Shell(const kitBase::robotModel::DeviceInfo &info
 	, mEngine(engine)
 	, mErrorReporter(nullptr)
 {
+	connect(this, &Shell::phraseTold, this, [=](const QString &text) { emit propertyChanged("lastPhrase", text); });
 }
 
 void Shell::runCommand(const QString &command)
@@ -47,6 +48,8 @@ void Shell::say(const QString &text)
 	if (mErrorReporter) {
 		mErrorReporter->sendBubblingMessage(text, 4000, mEngine.guiFacade().separateTwoDModelWindow());
 	}
+
+	emit phraseTold(text);
 }
 
 void Shell::writeToFile(const QString &filePath, const QString &text)

--- a/plugins/robots/utils/include/utils/canvas/arcObject.h
+++ b/plugins/robots/utils/include/utils/canvas/arcObject.h
@@ -68,6 +68,7 @@ public:
 	QRect boundingRect() const;
 
 	void paint(QPainter *painter) override;
+	QJsonObject toJson() const override;
 
 private:
 	QRect mRect;

--- a/plugins/robots/utils/include/utils/canvas/canvas.h
+++ b/plugins/robots/utils/include/utils/canvas/canvas.h
@@ -105,6 +105,9 @@ public:
 	/// call of setPainterWidth.
 	virtual void setPainterWidth(int penWidth);
 
+	/// Serializes shapes into one big JSON array and returns it.
+	QJsonArray toJson() const;
+
 	void paint(QPainter *painter) override;
 
 protected:

--- a/plugins/robots/utils/include/utils/canvas/canvasObject.h
+++ b/plugins/robots/utils/include/utils/canvas/canvasObject.h
@@ -50,6 +50,9 @@ public:
 	/// must be called to set pen and brush correctly.
 	virtual void paint(QPainter *painter);
 
+	/// Override must serialize current canvas object state into the instance of JSON object.
+	virtual QJsonObject toJson() const = 0;
+
 private:
 	QPen mPen;
 };

--- a/plugins/robots/utils/include/utils/canvas/ellipseObject.h
+++ b/plugins/robots/utils/include/utils/canvas/ellipseObject.h
@@ -60,6 +60,7 @@ public:
 	QRect boundingRect() const;
 
 	void paint(QPainter *painter) override;
+	QJsonObject toJson() const override;
 
 private:
 	QPoint mCenter;

--- a/plugins/robots/utils/include/utils/canvas/lineObject.h
+++ b/plugins/robots/utils/include/utils/canvas/lineObject.h
@@ -52,6 +52,7 @@ public:
 	QRect boundingRect() const;
 
 	void paint(QPainter *painter) override;
+	QJsonObject toJson() const override;
 
 private:
 	QPoint mBegin;

--- a/plugins/robots/utils/include/utils/canvas/pointObject.h
+++ b/plugins/robots/utils/include/utils/canvas/pointObject.h
@@ -48,6 +48,7 @@ public:
 	QPoint pos() const;
 
 	void paint(QPainter *painter) override;
+	QJsonObject toJson() const override;
 
 private:
 	int mX;

--- a/plugins/robots/utils/include/utils/canvas/rectangleObject.h
+++ b/plugins/robots/utils/include/utils/canvas/rectangleObject.h
@@ -38,6 +38,7 @@ public:
 	QRect boundingRect() const;
 
 	void paint(QPainter *painter) override;
+	QJsonObject toJson() const override;
 
 private:
 	QRect mShape;

--- a/plugins/robots/utils/include/utils/canvas/textObject.h
+++ b/plugins/robots/utils/include/utils/canvas/textObject.h
@@ -28,8 +28,6 @@ class ROBOTS_UTILS_EXPORT TextObject : public CanvasObject
 	Q_PROPERTY(int y READ y WRITE setY)
 	Q_PROPERTY(QPoint pos READ pos)
 	Q_PROPERTY(QString text READ text WRITE setText)
-	Q_PROPERTY(QColor color READ color WRITE setColor)
-	Q_PROPERTY(int thickness READ thickness WRITE setThickness)
 
 public:
 	explicit TextObject(QObject *parent = 0);
@@ -58,6 +56,7 @@ public:
 	void setText(const QString &text);
 
 	void paint(QPainter *painter) override;
+	QJsonObject toJson() const override;
 
 private:
 	int mX;

--- a/plugins/robots/utils/src/canvas/arcObject.cpp
+++ b/plugins/robots/utils/src/canvas/arcObject.cpp
@@ -14,6 +14,7 @@
 
 #include "utils/canvas/arcObject.h"
 
+#include <QtCore/QJsonObject>
 #include <QtGui/QPainter>
 
 using namespace utils;
@@ -82,4 +83,19 @@ void ArcObject::paint(QPainter *painter)
 	CanvasObject::paint(painter);
 	// Multiplying on 16 needed because Qt require argument in 1/16 degree format.
 	painter->drawArc(ellipseRect(), mStartAngle * 16, mSpanAngle * 16);
+}
+
+QJsonObject ArcObject::toJson() const
+{
+	return QJsonObject({
+		{ "type", "arc" }
+		, { "x", mRect.center().x() }
+		, { "y", mRect.center().y() }
+		, { "a", mRect.width() / 2 }
+		, { "b", mRect.height() / 2 }
+		, { "startAngle", mStartAngle }
+		, { "spanAngle", mSpanAngle }
+		, { "color", color().name() }
+		, { "thickness", thickness() }
+	});
 }

--- a/plugins/robots/utils/src/canvas/canvas.cpp
+++ b/plugins/robots/utils/src/canvas/canvas.cpp
@@ -14,6 +14,9 @@
 
 #include "utils/canvas/canvas.h"
 
+#include <QtCore/QJsonArray>
+#include <QtCore/QJsonObject>
+
 #include "utils/canvas/pointObject.h"
 #include "utils/canvas/lineObject.h"
 #include "utils/canvas/rectangleObject.h"
@@ -138,6 +141,16 @@ void Canvas::setPainterColor(const QColor &color)
 void Canvas::setPainterWidth(int penWidth)
 {
 	mCurrentPenWidth = penWidth;
+}
+
+QJsonArray Canvas::toJson() const
+{
+	QJsonArray result;
+	for (const CanvasObject *object : mObjects) {
+		result << object->toJson();
+	}
+
+	return result;
 }
 
 void Canvas::paint(QPainter *painter)

--- a/plugins/robots/utils/src/canvas/ellipseObject.cpp
+++ b/plugins/robots/utils/src/canvas/ellipseObject.cpp
@@ -14,6 +14,7 @@
 
 #include "utils/canvas/ellipseObject.h"
 
+#include <QtCore/QJsonObject>
 #include <QtGui/QPainter>
 
 using namespace utils;
@@ -73,4 +74,17 @@ void EllipseObject::paint(QPainter *painter)
 {
 	CanvasObject::paint(painter);
 	painter->drawEllipse(mCenter, mSemiDiameterX, mSemiDiameterY);
+}
+
+QJsonObject EllipseObject::toJson() const
+{
+	return QJsonObject({
+		{ "type", "ellipse" }
+		, { "x", mCenter.x() }
+		, { "y", mCenter.y() }
+		, { "a", mSemiDiameterX }
+		, { "b", mSemiDiameterY }
+		, { "color", color().name() }
+		, { "thickness", thickness() }
+	});
 }

--- a/plugins/robots/utils/src/canvas/lineObject.cpp
+++ b/plugins/robots/utils/src/canvas/lineObject.cpp
@@ -14,6 +14,7 @@
 
 #include "utils/canvas/lineObject.h"
 
+#include <QtCore/QJsonObject>
 #include <QtGui/QPainter>
 
 using namespace utils;
@@ -60,4 +61,17 @@ void LineObject::paint(QPainter *painter)
 {
 	CanvasObject::paint(painter);
 	painter->drawLine(mBegin, mEnd);
+}
+
+QJsonObject LineObject::toJson() const
+{
+	return QJsonObject({
+		{ "type", "line" }
+		, { "x1", mBegin.x() }
+		, { "y1", mBegin.y() }
+		, { "x2", mEnd.x() }
+		, { "y2", mEnd.y() }
+		, { "color", color().name() }
+		, { "thickness", thickness() }
+	});
 }

--- a/plugins/robots/utils/src/canvas/pointObject.cpp
+++ b/plugins/robots/utils/src/canvas/pointObject.cpp
@@ -14,6 +14,7 @@
 
 #include "utils/canvas/pointObject.h"
 
+#include <QtCore/QJsonObject>
 #include <QtGui/QPainter>
 
 using namespace utils;
@@ -61,4 +62,15 @@ void PointObject::paint(QPainter *painter)
 {
 	CanvasObject::paint(painter);
 	painter->drawPoint(mX, mY);
+}
+
+QJsonObject PointObject::toJson() const
+{
+	return QJsonObject({
+		{ "type", "point" }
+		, { "x", mX }
+		, { "y", mY }
+		, { "color", color().name() }
+		, { "thickness", thickness() }
+	});
 }

--- a/plugins/robots/utils/src/canvas/rectangleObject.cpp
+++ b/plugins/robots/utils/src/canvas/rectangleObject.cpp
@@ -14,6 +14,7 @@
 
 #include "utils/canvas/rectangleObject.h"
 
+#include <QtCore/QJsonObject>
 #include <QtGui/QPainter>
 
 using namespace utils;
@@ -43,4 +44,17 @@ void RectangleObject::paint(QPainter *painter)
 {
 	CanvasObject::paint(painter);
 	painter->drawRect(mShape);
+}
+
+QJsonObject RectangleObject::toJson() const
+{
+	return QJsonObject({
+		{ "type", "rectangle" }
+		, { "x", mShape.x() }
+		, { "y", mShape.y() }
+		, { "width", mShape.width() }
+		, { "height", mShape.height() }
+		, { "color", color().name() }
+		, { "thickness", thickness() }
+	});
 }

--- a/plugins/robots/utils/src/canvas/textObject.cpp
+++ b/plugins/robots/utils/src/canvas/textObject.cpp
@@ -14,6 +14,7 @@
 
 #include "utils/canvas/textObject.h"
 
+#include <QtCore/QJsonObject>
 #include <QtGui/QPainter>
 
 using namespace utils;
@@ -72,4 +73,16 @@ void TextObject::paint(QPainter *painter)
 {
 	CanvasObject::paint(painter);
 	painter->drawText(mX, mY, mText);
+}
+
+QJsonObject TextObject::toJson() const
+{
+	return QJsonObject({
+		{ "type", "text" }
+		, { "x", x() }
+		, { "y", y() }
+		, { "text", text() }
+		, { "color", color().name() }
+		, { "thickness", thickness() }
+	});
 }


### PR DESCRIPTION
Also couple of bugfixes made:
+ Fixed ablility to remove walls from read-only 2D model world
+ Restored updating sensor variables on-demand in wait blocks

Trajectory is now written in JSON. See this [manual](https://github.com/qreal/qreal/wiki/%D0%A4%D0%BE%D1%80%D0%BC%D0%B0%D1%82-%D0%B2%D1%8B%D0%B2%D0%BE%D0%B4%D0%B0-%D0%B8%D0%BD%D1%84%D0%BE%D1%80%D0%BC%D0%B0%D1%86%D0%B8%D0%B8-%D0%BE-%D1%81%D0%BE%D1%81%D1%82%D0%BE%D1%8F%D0%BD%D0%B8%D0%B8-%D1%80%D0%BE%D0%B1%D0%BE%D1%82%D0%B0-%D0%BF%D1%80%D0%BE%D0%B2%D0%B5%D1%80%D1%8F%D1%8E%D1%89%D0%B5%D0%B9-%D0%BF%D1%80%D0%BE%D0%B3%D1%80%D0%B0%D0%BC%D0%BC%D0%BE%D0%B9).