### PR TITLE
Small bugfixes for 3.1.1

### DIFF
--- a/installer/packages/qreal-base/ru.qreal.root.associations/meta/package.xml
+++ b/installer/packages/qreal-base/ru.qreal.root.associations/meta/package.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Package>
     <DisplayName>File associations</DisplayName>
-    <DisplayName xml:lang="ru_ru">Ассоциациировать файлы</DisplayName>
+    <DisplayName xml:lang="ru_ru">Ассоциировать файлы</DisplayName>
     <Description>Windows will open *.qrs-files with TRIK Studio by double-click on them</Description>
     <Description xml:lang="ru_ru">Windows будет открывать файлы *.qrs в TRIK Studio по двойному щелчку на них</Description>
     <Version>1.1.0</Version>

--- a/plugins/robots/checker/twoDModelRunner/main.cpp
+++ b/plugins/robots/checker/twoDModelRunner/main.cpp
@@ -16,6 +16,8 @@
 
 #include <QtCore/QDir>
 #include <QtCore/QCommandLineParser>
+#include <QtCore/QTranslator>
+#include <QtCore/QDirIterator>
 #include <QtWidgets/QApplication>
 
 #include <qrkernel/logging.h>
@@ -33,6 +35,28 @@ const QString description = QObject::tr(
 		"Example: \n") +
 		"    2D-model -b --platform minimal --report report.json --trajectory trajectory.fifo example.qrs";
 
+void loadTranslators(const QString &locale)
+{
+	QDir translationsDirectory(qReal::PlatformInfo::applicationDirPath() + "/translations/" + locale);
+	QDirIterator directories(translationsDirectory, QDirIterator::Subdirectories);
+	while (directories.hasNext()) {
+		for (const QFileInfo &translatorFile : QDir(directories.next()).entryInfoList(QDir::Files)) {
+			QTranslator *translator = new QTranslator(qApp);
+			translator->load(translatorFile.absoluteFilePath());
+			QCoreApplication::installTranslator(translator);
+		}
+	}
+}
+
+void setDefaultLocale()
+{
+	const QString locale = QLocale().name().left(2);
+	if (!locale.isEmpty()) {
+		QLocale::setDefault(QLocale(locale));
+		loadTranslators(locale);
+	}
+}
+
 void initLogging()
 {
 	const QDir logsDir(qReal::PlatformInfo::applicationDirPath() + "/logs");
@@ -46,6 +70,7 @@ int main(int argc, char *argv[])
 	QApplication app(argc, argv);
 	QCoreApplication::setApplicationName("2D-model");
 	QCoreApplication::setApplicationVersion("1.0");
+	setDefaultLocale();
 
 	QCommandLineParser parser;
 	parser.setApplicationDescription(description);

--- a/plugins/robots/common/twoDModel/include/twoDModel/engine/twoDModelControlInterface.h
+++ b/plugins/robots/common/twoDModel/include/twoDModel/engine/twoDModelControlInterface.h
@@ -22,6 +22,7 @@
 #include <qrgui/plugins/toolPluginInterface/usedInterfaces/graphicalModelAssistInterface.h>
 #include <qrgui/plugins/toolPluginInterface/usedInterfaces/logicalModelAssistInterface.h>
 #include <qrgui/plugins/toolPluginInterface/usedInterfaces/mainWindowInterpretersInterface.h>
+#include <qrgui/plugins/toolPluginInterface/usedInterfaces/projectManagementInterface.h>
 #include <kitBase/devicesConfigurationProvider.h>
 #include <kitBase/eventsForKitPluginInterface.h>
 #include <kitBase/interpreterControlInterface.h>
@@ -48,6 +49,7 @@ public:
 			, const qReal::SystemEvents &systemEvents
 			, qReal::LogicalModelAssistInterface &logicalModel
 			, qReal::gui::MainWindowInterpretersInterface &interpretersInterface
+			, const qReal::ProjectManagementInterface &projectManager
 			, kitBase::InterpreterControlInterface &interpreterControl) = 0;
 
 public slots:

--- a/plugins/robots/common/twoDModel/include/twoDModel/engine/twoDModelEngineFacade.h
+++ b/plugins/robots/common/twoDModel/include/twoDModel/engine/twoDModelEngineFacade.h
@@ -53,6 +53,7 @@ public:
 			, const qReal::SystemEvents &systemEvents
 			, qReal::LogicalModelAssistInterface &logicalModel
 			, qReal::gui::MainWindowInterpretersInterface &interpretersInterface
+			, const qReal::ProjectManagementInterface &projectManager
 			, kitBase::InterpreterControlInterface &interpreterControl) override;
 
 	kitBase::DevicesConfigurationProvider &devicesConfigurationProvider() override;

--- a/plugins/robots/common/twoDModel/src/engine/constraints/constraintsChecker.cpp
+++ b/plugins/robots/common/twoDModel/src/engine/constraints/constraintsChecker.cpp
@@ -66,6 +66,7 @@ bool ConstraintsChecker::parseConstraints(const QDomElement &constraintsXml)
 {
 	qDeleteAll(mEvents);
 	mEvents.clear();
+	mActiveEvents.clear();
 	mVariables.clear();
 
 	mCurrentXml = constraintsXml;

--- a/plugins/robots/common/twoDModel/src/engine/twoDModelEngineFacade.cpp
+++ b/plugins/robots/common/twoDModel/src/engine/twoDModelEngineFacade.cpp
@@ -47,14 +47,22 @@ void TwoDModelEngineFacade::init(const kitBase::EventsForKitPluginInterface &eve
 		, const qReal::SystemEvents &systemEvents
 		, qReal::LogicalModelAssistInterface &logicalModel
 		, qReal::gui::MainWindowInterpretersInterface &interpretersInterface
+		, const qReal::ProjectManagementInterface &projectManager
 		, kitBase::InterpreterControlInterface &interpreterControl)
 {
 	mModel->init(*interpretersInterface.errorReporter(), interpreterControl);
 
-	const auto onActiveTabChanged = [this, &logicalModel, &interpretersInterface](const qReal::TabInfo &info)
+	const auto onActiveTabChanged = [this](const qReal::TabInfo &info)
 	{
-		mView->setEnabled(info.type() == qReal::TabInfo::TabType::editor);
-		const QString xml = logicalModel.logicalRepoApi().metaInformation("worldModel").toString();
+		mView->setEnabled(info.type() != qReal::TabInfo::TabType::other);
+	};
+
+	const auto reloadWorld = [this, &logicalModel, &interpretersInterface, &projectManager]()
+	{
+		QLOG_DEBUG() << "Reloading 2D world model...";
+		const QString xml = projectManager.somethingOpened()
+				? logicalModel.logicalRepoApi().metaInformation("worldModel").toString()
+				: QString();
 		QDomDocument worldModel;
 		QString errorMessage;
 		int errorLine, errorColumn;
@@ -66,9 +74,10 @@ void TwoDModelEngineFacade::init(const kitBase::EventsForKitPluginInterface &eve
 		mView->loadXml(worldModel);
 
 		loadReadOnlyFlags(logicalModel);
+		QLOG_DEBUG() << "Reloading 2D world done";
 	};
 
-	auto connectTwoDModel = [this, &eventsForKitPlugin, &interpreterControl]()
+	const auto connectTwoDModel = [this, &eventsForKitPlugin, &interpreterControl]()
 	{
 		connect(&eventsForKitPlugin, &kitBase::EventsForKitPluginInterface::interpretationStarted
 				, this, &twoDModel::TwoDModelControlInterface::onStartInterpretation
@@ -102,6 +111,8 @@ void TwoDModelEngineFacade::init(const kitBase::EventsForKitPluginInterface &eve
 				, &interpreterControl, &kitBase::InterpreterControlInterface::stopRobot);
 	};
 
+	connect(&projectManager, &qReal::ProjectManagementInterface::afterOpen, this, reloadWorld);
+	connect(&projectManager, &qReal::ProjectManagementInterface::closed, this, reloadWorld);
 	connect(&systemEvents, &qReal::SystemEvents::activeTabChanged, this, onActiveTabChanged);
 
 	connect(mModel.data(), &model::Model::modelChanged, [this, &logicalModel] (const QDomDocument &xml) {

--- a/plugins/robots/editor/generated/robotsMetamodel.xml
+++ b/plugins/robots/editor/generated/robotsMetamodel.xml
@@ -2364,7 +2364,7 @@
 						<image y1="0" name="images/brushColorBlock.svg" x1="0" y2="50" x2="50"/>
 					</picture>
 					<labels>
-						<label x="-15" y="-35" text="Color:" hard="true" prefix="Color:"/>
+						<label x="25" y="-35" hard="true" prefix="Color:" textBinded="Color"/>
 					</labels>
 					<nonResizeable/>
 				</graphics>

--- a/plugins/robots/interpreters/nxtKitInterpreter/src/nxtKitInterpreterPlugin.cpp
+++ b/plugins/robots/interpreters/nxtKitInterpreter/src/nxtKitInterpreterPlugin.cpp
@@ -86,8 +86,8 @@ void NxtKitInterpreterPlugin::init(const kitBase::KitPluginConfigurator &configu
 			, configurator.qRealConfigurator().systemEvents()
 			, configurator.qRealConfigurator().logicalModelApi()
 			, interpretersInterface
+			, configurator.qRealConfigurator().projectManager()
 			, configurator.interpreterControl());
-
 }
 
 QString NxtKitInterpreterPlugin::kitId() const

--- a/plugins/robots/interpreters/trikKitInterpreterCommon/src/trikKitInterpreterPluginBase.cpp
+++ b/plugins/robots/interpreters/trikKitInterpreterCommon/src/trikKitInterpreterPluginBase.cpp
@@ -154,7 +154,10 @@ QWidget *TrikKitInterpreterPluginBase::produceIpAddressConfigurer()
 	quickPreferences->setSizePolicy(QSizePolicy::Preferred, QSizePolicy::Fixed);
 	quickPreferences->setPlaceholderText(tr("Enter robot`s IP-address here..."));
 	const auto updateQuickPreferences = [quickPreferences]() {
-		quickPreferences->setText(qReal::SettingsManager::value("TrikTcpServer").toString());
+		const QString ip = qReal::SettingsManager::value("TrikTcpServer").toString();
+		if (quickPreferences->text() != ip) {
+			quickPreferences->setText(ip);
+		}
 	};
 
 	updateQuickPreferences();

--- a/plugins/robots/interpreters/trikKitInterpreterCommon/src/trikKitInterpreterPluginBase.cpp
+++ b/plugins/robots/interpreters/trikKitInterpreterCommon/src/trikKitInterpreterPluginBase.cpp
@@ -73,6 +73,7 @@ void TrikKitInterpreterPluginBase::init(const kitBase::KitPluginConfigurator &co
 			, configurer.qRealConfigurator().systemEvents()
 			, configurer.qRealConfigurator().logicalModelApi()
 			, interpretersInterface
+			, configurer.qRealConfigurator().projectManager()
 			, configurer.interpreterControl());
 
 	mRealRobotModel->setErrorReporter(*interpretersInterface.errorReporter());

--- a/qrgui/mainWindow/main.cpp
+++ b/qrgui/mainWindow/main.cpp
@@ -45,7 +45,7 @@ void loadTranslators(const QString &locale)
 		for (const QFileInfo &translatorFile : QDir(directories.next()).entryInfoList(QDir::Files)) {
 			QTranslator *translator = new QTranslator(qApp);
 			translator->load(translatorFile.absoluteFilePath());
-			QApplication::installTranslator(translator);
+			QCoreApplication::installTranslator(translator);
 		}
 	}
 }

--- a/qrgui/systemFacade/components/consoleErrorReporter.cpp
+++ b/qrgui/systemFacade/components/consoleErrorReporter.cpp
@@ -33,7 +33,7 @@ void ConsoleErrorReporter::addWarning(const QString &message, const Id &position
 void ConsoleErrorReporter::addError(const QString &message, const Id &position)
 {
 	Q_UNUSED(position)
-	qDebug() << QObject::tr("Error:") << qUtf8Printable(message);
+	qDebug() << qUtf8Printable(QObject::tr("Error:")) << qUtf8Printable(message);
 	mWereErrors = true;
 	emit errorAdded(message, position);
 }

--- a/qrgui/systemFacade/components/nullMainWindow.cpp
+++ b/qrgui/systemFacade/components/nullMainWindow.cpp
@@ -57,7 +57,6 @@ NullMainWindow::NullMainWindow(ErrorReporterInterface &errorReporter
 NullMainWindow::~NullMainWindow()
 {
 	delete mWindowWidget;
-	SettingsManager::instance()->saveData();
 }
 
 

--- a/qrgui/systemFacade/components/projectManager.cpp
+++ b/qrgui/systemFacade/components/projectManager.cpp
@@ -142,11 +142,12 @@ bool ProjectManager::openProject(const QString &fileName)
 	setSaveFilePath(fileName);
 	refreshApplicationStateAfterOpen();
 
+	mSomeProjectOpened = true;
+	QLOG_INFO() << "Opened project" << fileName;
+	QLOG_DEBUG() << "Sending after open signal...";
+
 	emit afterOpen(fileName);
 
-	mSomeProjectOpened = true;
-
-	QLOG_INFO() << "Opened project" << fileName;
 
 	return true;
 }


### PR DESCRIPTION
+ Checker is now localizable via _LANG=.._
+ Disabled settings saving by checker (now)
+ Disabled 2D world model reloading on tabs switching
+ Fixed unexpected cursor behaviour in IP address configurers
+ Fixed hanging events in 2D model constraints checker
+ Fixed SetPainterColor block scene label contents
+ Fixed misprint in ru.qreal.root.associations russian component name