### PR TITLE
Added support for Appveyor CI

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -6,8 +6,8 @@ environment:
     MINGW: C:\Qt\Tools\mingw492_32
     QTDIR: C:\Qt\5.5\mingw492_32
   matrix:
-    - PROJECT_FILE: qrealRobots.pro
-    - PROJECT_FILE: qreal.pro
+    - PROJECT_FILE: qrealRobots
+    - PROJECT_FILE: qreal
 #   - PROJECT_FILE: qrealMinimal.pro
 
 configuration:
@@ -17,5 +17,9 @@ configuration:
 install:
   - set PATH=%QTDIR%\bin;%MINGW%\bin;%WINDIR%\system32;%WINDIR%;%WINDIR%\System32\WindowsPowerShell\v1.0\;
 build_script:
-  - qmake %PROJECT_FILE% -r -spec win32-g++ CONFIG+=%CONFIGURATION%
+  - qmake %PROJECT_FILE%.pro -r -spec win32-g++ CONFIG+=%CONFIGURATION%
   - mingw32-make -j2
+  
+artifacts:
+ - path: bin\$(configuration)
+   name: qreal-$(configuration)-$(PROJECT_FILE)

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,0 +1,21 @@
+clone_folder: c:\qreal
+test: off
+
+environment:
+  global:
+    MINGW: C:\Qt\Tools\mingw492_32
+    QTDIR: C:\Qt\5.5\mingw492_32
+  matrix:
+    - PROJECT_FILE: qrealRobots.pro
+    - PROJECT_FILE: qreal.pro
+#   - PROJECT_FILE: qrealMinimal.pro
+
+configuration:
+  - debug
+  - release
+
+install:
+  - set PATH=%QTDIR%\bin;%MINGW%\bin;%WINDIR%\system32;%WINDIR%;%WINDIR%\System32\WindowsPowerShell\v1.0\;
+build_script:
+  - qmake %PROJECT_FILE% -r -spec win32-g++ CONFIG+=%CONFIGURATION%
+  - mingw32-make -j2


### PR DESCRIPTION
To test windows builds (could function as a build bot too - see artifacts).
One downside compared to travis - only 1 concurrent job.
Currently qreal.pro doesn't build. Could be "skipped": http://www.appveyor.com/docs/build-configuration#failing-strategy
