### PR TITLE
Editor clean up part 1: elements selection code

### DIFF
--- a/qrgui/editor/editorView.cpp
+++ b/qrgui/editor/editorView.cpp
@@ -164,11 +164,7 @@ void EditorView::mouseMoveEvent(QMouseEvent *event)
 	} else {
 		if ((event->buttons() & Qt::LeftButton) && (event->modifiers() & Qt::ControlModifier)) {
 			setDragMode(RubberBandDrag);
-			mScene.itemSelectUpdate();
-		/*} else 	if ((event->buttons() & Qt::LeftButton) && (event->modifiers() & Qt::ShiftModifier)) {
-			setDragMode(ScrollHandDrag); //  (see #615)
-			mScene->itemSelectUpdate();*/
-		} else if (event->buttons() & Qt::LeftButton ) {
+		} else if (event->buttons() & Qt::LeftButton) {
 			EdgeElement *newEdgeEl = dynamic_cast<EdgeElement *>(itemAt(event->pos()));
 			if (newEdgeEl && newEdgeEl->isBreakPointPressed()) {
 				newEdgeEl->breakPointUnpressed();
@@ -204,10 +200,6 @@ void EditorView::mousePressEvent(QMouseEvent *event)
 		if (!(event->buttons() & Qt::RightButton) && !mTouchManager.isGestureRunning()
 				&& !itemAt(event->pos())) {
 			setDragMode(RubberBandDrag);
-		}
-
-		if (event->modifiers() & Qt::ControlModifier) {
-			mScene.itemSelectUpdate();
 		}
 	}
 }

--- a/qrgui/editor/editorViewScene.h
+++ b/qrgui/editor/editorViewScene.h
@@ -123,8 +123,6 @@ public:
 	NodeElement* getNodeById(const qReal::Id &itemId) const;
 	EdgeElement* getEdgeById(const qReal::Id &itemId) const;
 
-	void itemSelectUpdate();
-
 	/// update (for a beauty) all edges when tab is opening
 	void initNodes();
 
@@ -179,9 +177,6 @@ signals:
 		, const EditorManagerInterface *editorManagerProxy
 		, bool useTypedPorts);
 
-	/// Emitted a set of selected editor elements has changed.
-	void sceneSelectionChanged(const QList<Element *> &elements);
-
 protected:
 	void dragEnterEvent(QGraphicsSceneDragDropEvent *event);
 	void dragMoveEvent(QGraphicsSceneDragDropEvent *event);
@@ -209,7 +204,6 @@ private slots:
 	/// Updates repository after the move. Controled by the timer.
 	void updateMovedElements();
 
-	void onSelectionChanged();
 	void deselectLabels();
 
 private:
@@ -283,10 +277,6 @@ private:
 	QGraphicsRectItem *mTopLeftCorner;
 	QGraphicsRectItem *mBottomRightCorner;
 
-	/** @brief list of selected items for additional selection */
-	QList<QGraphicsItem* > mSelectList;
-
-	bool mIsSelectEvent;
 	bool mMouseGesturesEnabled;
 
 	QMenu mContextMenu;

--- a/qrgui/editor/element.cpp
+++ b/qrgui/editor/element.cpp
@@ -101,29 +101,6 @@ void Element::initTitles()
 {
 }
 
-void Element::select(const bool singleSelected)
-{
-	if (singleSelected) {
-		setSelectionState(true);
-	}
-
-	emit switchFolding(!singleSelected);
-}
-
-void Element::setSelectionState(const bool selected)
-{
-	if (isSelected() != selected) {
-		setSelected(selected);
-	}
-	if (!selected) {
-		select(false);
-	}
-
-	for (Label * const label : mLabels) {
-		label->setParentSelected(selected);
-	}
-}
-
 ElementImpl* Element::elementImpl() const
 {
 	return mElementImpl;
@@ -154,12 +131,6 @@ void Element::updateEnabledState()
 
 void Element::setHideNonHardLabels(bool hide)
 {
-	for (const Label * const label : mLabels) {
-		if (label->isSelected()) {
-			return;
-		}
-	}
-
 	for (Label * const label : mLabels) {
 		label->setVisible(label->isHard() || !hide);
 	}

--- a/qrgui/editor/element.h
+++ b/qrgui/editor/element.h
@@ -87,13 +87,6 @@ public:
 	/// Checks if this element is disabled from palette and if it is grayscales it.
 	void updateEnabledState();
 
-public slots:
-	virtual void select(const bool singleSelected);
-	virtual void setSelectionState(const bool selected);
-
-signals:
-	void switchFolding(bool);
-
 protected:
 	void setHideNonHardLabels(bool visible);
 

--- a/qrgui/editor/embedded/linkers/embeddedLinker.cpp
+++ b/qrgui/editor/embedded/linkers/embeddedLinker.cpp
@@ -267,7 +267,7 @@ void EmbeddedLinker::mouseMoveEvent(QGraphicsSceneMouseEvent *event)
 void EmbeddedLinker::mouseReleaseEvent(QGraphicsSceneMouseEvent *event)
 {
 	hide();
-	mMaster->setSelectionState(false);
+	mMaster->setSelected(false);
 	EditorViewScene* scene = dynamic_cast<EditorViewScene*>(mMaster->scene());
 
 	if (!mPressed && scene && mEdge) {

--- a/qrgui/editor/labels/label.cpp
+++ b/qrgui/editor/labels/label.cpp
@@ -26,7 +26,6 @@ Label::Label(models::GraphicalModelAssistApi &graphicalAssistApi
 		, const Id &elementId
 		, const LabelProperties &properties)
 	: mIsStretched(false)
-	, mParentIsSelected(false)
 	, mWasMoved(false)
 	, mShouldMove(false)
 	, mId(elementId)
@@ -106,11 +105,6 @@ void Label::setTextFromRepo(const QString &text)
 		setText(toPlainText());
 		updateData();
 	}
-}
-
-void Label::setParentSelected(bool isSelected)
-{
-	mParentIsSelected = isSelected;
 }
 
 void Label::setParentContents(const QRectF &contents)
@@ -202,6 +196,7 @@ void Label::mousePressEvent(QGraphicsSceneMouseEvent *event)
 			&& event->pos().y() >= boundingRect().bottom() - 10);
 
 	QGraphicsTextItem::mousePressEvent(event);
+	parentItem()->setSelected(true);
 	event->accept();
 }
 
@@ -237,6 +232,7 @@ void Label::mouseReleaseEvent(QGraphicsSceneMouseEvent *event)
 	updateData();
 
 	QGraphicsTextItem::mouseReleaseEvent(event);
+	parentItem()->setSelected(true);
 	setSelected(true);
 }
 
@@ -358,7 +354,9 @@ void Label::startTextInteraction()
 
 void Label::paint(QPainter *painter, const QStyleOptionGraphicsItem *option, QWidget *widget)
 {
-	if (toPlainText().isEmpty() && !mParentIsSelected && !isSelected() && dynamic_cast<EdgeElement *>(parentItem())) {
+	if (toPlainText().isEmpty() && !parentItem()->isSelected()
+			&& !isSelected() && dynamic_cast<EdgeElement *>(parentItem())) {
+		/// @todo: Why label decides it? Why not edge element itself?
 		return;
 	}
 

--- a/qrgui/editor/labels/label.h
+++ b/qrgui/editor/labels/label.h
@@ -97,7 +97,6 @@ private:
 	QRectF mParentContents;
 	QString mOldText;
 	bool mIsStretched;
-	bool mParentIsSelected;
 	bool mWasMoved;
 	bool mShouldMove;
 	const Id mId;

--- a/qrgui/editor/nodeElement.h
+++ b/qrgui/editor/nodeElement.h
@@ -196,8 +196,6 @@ public:
 	IdList sortedChildren() const;
 
 public slots:
-	virtual void select(const bool singleSelected);
-	virtual void setSelectionState(const bool selected);
 	void switchGrid(bool isChecked);
 	NodeElement *copyAndPlaceOnDiagram(const QPointF &offset);
 
@@ -244,14 +242,14 @@ private:
 
 	void initPortsVisibility();
 
-	virtual void mousePressEvent(QGraphicsSceneMouseEvent *event);
-	virtual void mouseMoveEvent(QGraphicsSceneMouseEvent *event);
-	virtual void mouseReleaseEvent(QGraphicsSceneMouseEvent *event);
-	virtual void mouseDoubleClickEvent (QGraphicsSceneMouseEvent *event);
+	void mousePressEvent(QGraphicsSceneMouseEvent *event) override;
+	void mouseMoveEvent(QGraphicsSceneMouseEvent *event) override;
+	void mouseReleaseEvent(QGraphicsSceneMouseEvent *event) override;
+	void mouseDoubleClickEvent (QGraphicsSceneMouseEvent *event) override;
 
-	virtual void hoverEnterEvent(QGraphicsSceneHoverEvent *event);
-	virtual void hoverMoveEvent(QGraphicsSceneHoverEvent *event);
-	virtual void hoverLeaveEvent(QGraphicsSceneHoverEvent *event);
+	void hoverEnterEvent(QGraphicsSceneHoverEvent *event) override;
+	void hoverMoveEvent(QGraphicsSceneHoverEvent *event) override;
+	void hoverLeaveEvent(QGraphicsSceneHoverEvent *event) override;
 
 	void paint(QPainter *p, const QStyleOptionGraphicsItem *opt);
 	void drawPorts(QPainter *painter, bool mouseOver);
@@ -261,12 +259,13 @@ private:
 	 * @param mouseScenePos Current mouse scene position.
 	 */
 	void recalculateHighlightedNode(const QPointF &mouseScenePos);
-	virtual QVariant itemChange(GraphicsItemChange change, const QVariant &value);
+	QVariant itemChange(GraphicsItemChange change, const QVariant &value) override;
 
 	void setLinksVisible(bool);
 
 	void updateByChild(NodeElement *item, bool isItemAddedOrDeleted);
 	void updateByNewParent();
+	void updateBySelection();
 
 	void updateChildrenOrder();
 

--- a/qrgui/editor/private/editorViewMVIface.cpp
+++ b/qrgui/editor/private/editorViewMVIface.cpp
@@ -209,20 +209,12 @@ void EditorViewMViface::rowsInserted(const QModelIndex &parent, int start, int e
 			}
 
 			if (!isEdgeFromEmbeddedLinker) {
-				for (QGraphicsItem *item : scene()->items()) {
-					Element* element = dynamic_cast<Element*>(item);
-					if (element) {
-						element->setSelectionState(false);
-						element->select(false);
-					}
-				}
-
-				elem->select(true);
+				mView->scene()->clearSelection();
+				elem->setSelected(true);
 			}
 
-			NodeElement* nodeElem = dynamic_cast<NodeElement*>(elem);
-			if (nodeElem && currentId.element() == "Class" &&
-				mGraphicalAssistApi->children(currentId).empty())
+			if (dynamic_cast<NodeElement *>(elem) && currentId.element() == "Class" &&
+					mGraphicalAssistApi->children(currentId).empty())
 			{
 				needToProcessChildren = false;
 				for (int i = 0; i < 2; i++) {

--- a/qrgui/mainWindow/mainWindow.h
+++ b/qrgui/mainWindow/mainWindow.h
@@ -249,7 +249,7 @@ private slots:
 	void makeSvg();
 	void showGrid(bool isChecked);
 
-	void sceneSelectionChanged(const QList<Element *> &elements);
+	void sceneSelectionChanged();
 
 	void applySettings();
 	void resetToolbarSize(int size);


### PR DESCRIPTION
Removed tones of copro-code from editor implementing elements selection logic already available in QGraphicsScene in a bad way. 200 lines of horrible spaghetti code synthesizing mouse events and disabling mouse buttons for editor elements simply removed and editor behavior is just the same after that (yet need to be tested thoroughly), at least with TRIK Studio editor.  

By the way, ctrl+a action performance improved a lot. For save with 1024 initial nodes (see attached image) ctrl+a improved from **3920.25** ms to **851** ms (10 experiments with both versions).

![image](https://cloud.githubusercontent.com/assets/734254/11454461/112b8f14-963e-11e5-8962-3cc113e518ff.png)