### PR TITLE
Fixes for non-hard labels in editor

### DIFF
--- a/qrgui/editor/editorViewScene.cpp
+++ b/qrgui/editor/editorViewScene.cpp
@@ -246,6 +246,7 @@ void EditorViewScene::dropEvent(QGraphicsSceneDragDropEvent *event)
 		return;
 	}
 
+	clearSelection();
 	createElement(event->mimeData(), event->scenePos());
 	if (mHighlightNode) {
 		mHighlightNode->erasePlaceholder(true);
@@ -387,6 +388,9 @@ void EditorViewScene::createElement(const QMimeData *mimeData
 {
 	ElementInfo elementInfo = ElementInfo::fromMimeData(mimeData);
 	createElement(elementInfo, scenePos, createCommandPointer, executeImmediately);
+	if (Element * const element = getElem(elementInfo.id())) {
+		element->setSelected(true);
+	}
 }
 
 void EditorViewScene::createElement(const ElementInfo &elementInfo

--- a/qrgui/editor/element.cpp
+++ b/qrgui/editor/element.cpp
@@ -131,7 +131,7 @@ void Element::updateEnabledState()
 void Element::setHideNonHardLabels(bool hide)
 {
 	for (Label * const label : mLabels) {
-		label->setVisible(label->isHard() || !hide);
+		label->setVisible(label->isHard() || !hide || label->isSelected());
 	}
 }
 

--- a/qrgui/editor/labels/label.cpp
+++ b/qrgui/editor/labels/label.cpp
@@ -199,6 +199,7 @@ void Label::mousePressEvent(QGraphicsSceneMouseEvent *event)
 	QGraphicsTextItem::mousePressEvent(event);
 	parentItem()->setSelected(true);
 	event->accept();
+	setSelected(true);
 }
 
 void Label::mouseMoveEvent(QGraphicsSceneMouseEvent *event)

--- a/qrgui/editor/private/touchSupportManager.cpp
+++ b/qrgui/editor/private/touchSupportManager.cpp
@@ -59,7 +59,7 @@ bool TouchSupportManager::eventFilter(QObject *object, QEvent *event)
 		return false;
 	}
 
-	QMouseEvent * const mouseEvent = static_cast<QMouseEvent *>(event);
+	QMouseEvent * const mouseEvent = dynamic_cast<QMouseEvent *>(event);
 #if(QT_VERSION >= QT_VERSION_CHECK(5, 3, 0))
 	if (isMouseEvent && mouseEvent->source() != Qt::MouseEventNotSynthesized) {
 		// Starting from version 5.3.0 Qt generates extra mouse events even on


### PR DESCRIPTION
Non-hard labels are now shown when element dropped on scene and text is again selectable by mouse.
Also fixed ubsan warning when pressing and holding mouse.