### PR TITLE
Critical editor fixes

### DIFF
--- a/qrgui/editor/element.cpp
+++ b/qrgui/editor/element.cpp
@@ -19,6 +19,7 @@
 
 #include <qrkernel/settingsListener.h>
 #include <qrgui/models/models.h>
+#include <qrgui/models/commands/renameCommand.h>
 #include <qrgui/models/commands/changePropertyCommand.h>
 
 #include "qrgui/editor/labels/label.h"
@@ -67,6 +68,19 @@ QString Element::name() const
 void Element::updateData()
 {
 	setToolTip(mGraphicalAssistApi.toolTip(id()));
+}
+
+void Element::setName(const QString &value, bool withUndoRedo)
+{
+	commands::AbstractCommand *command = new commands::RenameCommand(mGraphicalAssistApi
+			, id(), value, &mModels.exploser());
+	if (withUndoRedo) {
+		mController->execute(command);
+		// Controller will take ownership
+	} else {
+		command->redo();
+		delete command;
+	}
 }
 
 QString Element::logicalProperty(const QString &roleName) const

--- a/qrgui/editor/element.h
+++ b/qrgui/editor/element.h
@@ -67,6 +67,8 @@ public:
 
 	virtual bool initPossibleEdges() = 0;
 	virtual void initTitles();
+
+	virtual void setName(const QString &name, bool withUndoRedo = false);
 	// for inline editing we should be able to change properties value. right now via graphical
 	// representation. also labels could store indices and get data themselves
 	virtual void setLogicalProperty(const QString &roleName, const QString &value

--- a/qrgui/editor/labels/label.cpp
+++ b/qrgui/editor/labels/label.cpp
@@ -164,7 +164,7 @@ void Label::setSuffix(const QString &text)
 void Label::updateData(bool withUndoRedo)
 {
 	const QString value = toPlainText();
-	NodeElement * const parent = static_cast<NodeElement *>(parentItem());
+	Element * const parent = dynamic_cast<Element *>(parentItem());
 	if (mProperties.binding() == "name") {
 		parent->setName(value, withUndoRedo);
 	} else if (mEnumValues.isEmpty()) {

--- a/qrgui/editor/nodeElement.cpp
+++ b/qrgui/editor/nodeElement.cpp
@@ -28,7 +28,6 @@
 
 #include <qrgui/models/models.h>
 #include <qrgui/models/commands/changeParentCommand.h>
-#include <qrgui/models/commands/renameCommand.h>
 #include <qrgui/plugins/editorPluginInterface/editorInterface.h>
 
 #include "editor/labels/label.h"
@@ -49,7 +48,6 @@ using namespace qReal::gui::editor::commands;
 
 NodeElement::NodeElement(ElementImpl *impl, const Id &id, const models::Models &models)
 	: Element(impl, id, models)
-	, mExploser(models.exploser())
 	, mSwitchGridAction(tr("Switch on grid"), this)
 	, mDragState(None)
 	, mResizeCommand(nullptr)
@@ -147,18 +145,6 @@ QMap<QString, QVariant> NodeElement::graphicalProperties() const
 QMap<QString, QVariant> NodeElement::logicalProperties() const
 {
 	return mGraphicalAssistApi.properties(logicalId());
-}
-
-void NodeElement::setName(const QString &value, bool withUndoRedo)
-{
-	AbstractCommand *command = new RenameCommand(mGraphicalAssistApi, id(), value, &mExploser);
-	if (withUndoRedo) {
-		mController->execute(command);
-		// Controller will take ownership
-	} else {
-		command->redo();
-		delete command;
-	}
 }
 
 void NodeElement::setGeometry(const QRectF &geom)
@@ -1357,7 +1343,7 @@ void NodeElement::initRenderedDiagram()
 	EditorView view(evScene->models(), evScene->controller(), evScene->customizer(), graphicalDiagram);
 	view.mutableScene().setNeedDrawGrid(false);
 
-	view.mutableMvIface().configure(mGraphicalAssistApi, mLogicalAssistApi, mExploser);
+	view.mutableMvIface().configure(mGraphicalAssistApi, mLogicalAssistApi, mModels.exploser());
 	view.mutableMvIface().setModel(evScene->models().graphicalModel());
 	view.mutableMvIface().setLogicalModel(evScene->models().logicalModel());
 	view.mutableMvIface().setRootIndex(mGraphicalAssistApi.indexById(graphicalDiagram));

--- a/qrgui/editor/nodeElement.h
+++ b/qrgui/editor/nodeElement.h
@@ -83,7 +83,6 @@ public:
 	bool isContainer() const;
 
 	void storeGeometry();
-	virtual void setName(const QString &name, bool withUndoRedo = false);
 
 	/// Returns port position relative to the top left corner of NodeElement
 	/// (position of NodeElement).
@@ -262,7 +261,6 @@ private:
 	QRectF diagramRenderingRect() const;
 
 	qReal::commands::AbstractCommand *changeParentCommand(const Id &newParent, const QPointF &position) const;
-	models::Exploser &mExploser;
 
 	ContextMenuAction mSwitchGridAction;
 

--- a/qrgui/mainWindow/startWidget/startWidget.cpp
+++ b/qrgui/mainWindow/startWidget/startWidget.cpp
@@ -280,7 +280,7 @@ QWidget *StartWidget::createPluginButton(const Id &editor, const Id &diagram, QW
 	QSignalMapper *pluginMapper = new QSignalMapper(result);
 	pluginMapper->setMapping(result, "qrm:/" + editor.editor() + "/" + diagram.diagram() + "/" + diagramNodeName);
 	connect(result, SIGNAL(clicked()), pluginMapper, SLOT(map()));
-	connect(pluginMapper, SIGNAL(mapped(QString)), mMainWindow, SLOT(createDiagram(QString)));
+	connect(pluginMapper, SIGNAL(mapped(QString)), mMainWindow, SLOT(createProject(QString)));
 
 	return result;
 }

--- a/qrgui/models/commands/changePropertyCommand.cpp
+++ b/qrgui/models/commands/changePropertyCommand.cpp
@@ -21,23 +21,7 @@ ChangePropertyCommand::ChangePropertyCommand(models::LogicalModelAssistApi * con
 	: mLogicalModel(model)
 	, mId(id)
 	, mPropertyName(property)
-	, mPropertyEditorModel(nullptr)
 	, mOldValue(mLogicalModel->propertyByRoleName(mId, mPropertyName))
-	, mNewValue(newValue)
-{
-}
-
-ChangePropertyCommand::ChangePropertyCommand(
-		PropertyEditorModel * const model
-		, const QModelIndex &index
-		, const QVariant &oldValue
-		, const QVariant &newValue
-		, int role)
-	: mLogicalModel(nullptr)
-	, mPropertyEditorModel(model)
-	, mPropertyEditorIndex(index)
-	, mPropertyEditorRole(role)
-	, mOldValue(oldValue)
 	, mNewValue(newValue)
 {
 }
@@ -54,9 +38,6 @@ bool ChangePropertyCommand::restoreState()
 
 bool ChangePropertyCommand::setProperty(const QVariant &value)
 {
-	if (mPropertyEditorModel) {
-		return mPropertyEditorModel->setData(mPropertyEditorIndex, value, mPropertyEditorRole);
-	}
 	mLogicalModel->setPropertyByRoleName(mId, value, mPropertyName);
 	return true;
 }

--- a/qrgui/models/commands/changePropertyCommand.h
+++ b/qrgui/models/commands/changePropertyCommand.h
@@ -32,15 +32,6 @@ public:
 	ChangePropertyCommand(models::LogicalModelAssistApi * const model
 			, const QString &property, const Id &id, const QVariant &newValue);
 
-	/// Constructs new change property command instance modifying
-	/// properties via property editor proxy model
-	ChangePropertyCommand(
-		PropertyEditorModel * const model /* Doesn`t take ownership */
-		, const QModelIndex &index
-		, const QVariant &oldValue
-		, const QVariant &newValue
-		, int role = Qt::EditRole);
-
 protected:
 	virtual bool execute();
 	virtual bool restoreState();
@@ -51,10 +42,6 @@ private:
 	models::LogicalModelAssistApi *mLogicalModel;
 	const Id mId;
 	QString mPropertyName;
-
-	PropertyEditorModel *mPropertyEditorModel;
-	QModelIndex mPropertyEditorIndex;
-	int mPropertyEditorRole;
 
 	QVariant mOldValue;
 	QVariant mNewValue;

--- a/qrgui/models/propertyEditorModel.cpp
+++ b/qrgui/models/propertyEditorModel.cpp
@@ -307,6 +307,27 @@ QString PropertyEditorModel::typeName(const QModelIndex &index) const
 	return mEditorManagerInterface.typeName(id, mFields[index.row()].fieldName);
 }
 
+QString PropertyEditorModel::propertyName(const QModelIndex &index) const
+{
+	return mFields[index.row()].fieldName;
+}
+
+bool PropertyEditorModel::setData(const Id &id, const QString &propertyName, const QVariant &value)
+{
+	if (mFields.isEmpty() || idByIndex(index(0, 0)) != id) {
+		return false;
+	}
+
+	for (const Field &field : mFields) {
+		if (field.fieldName == propertyName) {
+			setData(index(field.role, 1), value);
+			return true;
+		}
+	}
+
+	return false;
+}
+
 bool PropertyEditorModel::isReference(const QModelIndex &index, const QString &propertyName)
 {
 	Id id = idByIndex(index);

--- a/qrgui/models/propertyEditorModel.h
+++ b/qrgui/models/propertyEditorModel.h
@@ -53,6 +53,14 @@ public:
 	// Methods needed by "Reference button" delegate
 	QString typeName(const QModelIndex &index) const;
 
+	/// Returns internal (not displayed) property name of the given index.
+	QString propertyName(const QModelIndex &index) const;
+
+	/// Overload for convenience.
+	/// May not set actual property value if element different from \a id is selected. False will be returned then,
+	/// if property was successully setted true will be returned.
+	bool setData(const qReal::Id &id, const QString &propertyName, const QVariant &value);
+
 	// Methods for use in delegate, allow to determine where in actual models to put data
 	QModelIndex modelIndex(int row) const;
 	int roleByIndex(int row) const;


### PR DESCRIPTION
- Fixed segfault of QReal editor after sequential creating diagram via start widget and diagrams modal dialog
- Fixed segfaulting after undoing property editor modification when other element is selected
- Fixed showing edge labels modifications in property editor
