### PR TITLE
Fixes for EV3 support

### DIFF
--- a/plugins/robots/generators/ev3/ev3RbfGenerator/ev3RbfGeneratorPlugin.cpp
+++ b/plugins/robots/generators/ev3/ev3RbfGenerator/ev3RbfGeneratorPlugin.cpp
@@ -52,7 +52,7 @@ Ev3RbfGeneratorPlugin::Ev3RbfGeneratorPlugin()
 	mStopRobotAction->setIcon(QIcon(":/ev3/rbf/images/stop.png"));
 	connect(mStopRobotAction, &QAction::triggered, this, &Ev3RbfGeneratorPlugin::stopRobot, Qt::UniqueConnection);
 
-	text::Languages::registerLanguage(text::LanguageInfo{ "rbf"
+	text::Languages::registerLanguage(text::LanguageInfo{ "lms"
 			, tr("EV3 Source Code language")
 			, true
 			, 4
@@ -104,7 +104,7 @@ QString Ev3RbfGeneratorPlugin::defaultFilePath(QString const &projectName) const
 
 text::LanguageInfo Ev3RbfGeneratorPlugin::language() const
 {
-	return text::Languages::pickByExtension("rbf");
+	return text::Languages::pickByExtension("lms");
 }
 
 QString Ev3RbfGeneratorPlugin::generatorName() const

--- a/plugins/robots/generators/ev3/ev3RbfGenerator/templates/luaPrinting/greaterOrEqual.t
+++ b/plugins/robots/generators/ev3/ev3RbfGenerator/templates/luaPrinting/greaterOrEqual.t
@@ -1,1 +1,1 @@
-CP_GTEQF@@TYPE@@(@@LEFT@@, @@RIGHT@@, @@RESULT@@)
+CP_GTEQ@@TYPE@@(@@LEFT@@, @@RIGHT@@, @@RESULT@@)

--- a/plugins/robots/generators/ev3/ev3RbfGenerator/templates/luaPrinting/greaterThan.t
+++ b/plugins/robots/generators/ev3/ev3RbfGenerator/templates/luaPrinting/greaterThan.t
@@ -1,1 +1,1 @@
-CP_GTF@@TYPE@@(@@LEFT@@, @@RIGHT@@, @@RESULT@@)
+CP_GT@@TYPE@@(@@LEFT@@, @@RIGHT@@, @@RESULT@@)

--- a/plugins/robots/generators/ev3/ev3RbfGenerator/templates/luaPrinting/lessOrEqual.t
+++ b/plugins/robots/generators/ev3/ev3RbfGenerator/templates/luaPrinting/lessOrEqual.t
@@ -1,1 +1,1 @@
-CP_LTEQF@@TYPE@@(@@LEFT@@, @@RIGHT@@, @@RESULT@@)
+CP_LTEQ@@TYPE@@(@@LEFT@@, @@RIGHT@@, @@RESULT@@)

--- a/plugins/robots/generators/ev3/ev3RbfGenerator/templates/luaPrinting/lessThan.t
+++ b/plugins/robots/generators/ev3/ev3RbfGenerator/templates/luaPrinting/lessThan.t
@@ -1,1 +1,1 @@
-CP_LTF@@TYPE@@(@@LEFT@@, @@RIGHT@@, @@RESULT@@)
+CP_LT@@TYPE@@(@@LEFT@@, @@RIGHT@@, @@RESULT@@)


### PR DESCRIPTION
+ Fixed comparison operators generation into bytecode (thanks to Alexander Grigoriev for reporting)
+ Extension in file dialog masks changed to "lms" in EV3 bytecode generator plugin