### PR TITLE
Emulate script.timer() using 2d model timer

### DIFF
--- a/plugins/robots/common/twoDModel/src/engine/model/modelTimer.cpp
+++ b/plugins/robots/common/twoDModel/src/engine/model/modelTimer.cpp
@@ -32,6 +32,11 @@ bool ModelTimer::isTicking() const
 	return mListening;
 }
 
+int ModelTimer::interval() const
+{
+	return mInterval;
+}
+
 void ModelTimer::start()
 {
 	start(mInterval);

--- a/plugins/robots/common/twoDModel/src/engine/model/modelTimer.h
+++ b/plugins/robots/common/twoDModel/src/engine/model/modelTimer.h
@@ -30,6 +30,7 @@ public:
 	explicit ModelTimer(const Timeline *timeline /* Doesn`t take ownership */);
 
 	bool isTicking() const override;
+	int interval() const override;
 	void start() override;
 	void start(int ms) override;
 	void stop() override;

--- a/plugins/robots/interpreters/trikKitInterpreterCommon/include/trikKitInterpreterCommon/trikbrick.h
+++ b/plugins/robots/interpreters/trikKitInterpreterCommon/include/trikKitInterpreterCommon/trikbrick.h
@@ -19,6 +19,10 @@
 #include "trikEmulation/trikaccelerometeradapter.h"
 #include "trikEmulation/trikGyroscopeAdapter.h" /// @todo: replace with forward refs
 
+namespace utils {
+class AbstractTimer;
+}
+
 namespace trik {
 
 class TrikBrick final : public trikControl::BrickInterface
@@ -74,6 +78,8 @@ public slots:
 	void wait(int milliseconds);
 	qint64 time() const;
 	QStringList readAll(const QString &path);
+	/// In trikRuntime returns QTimer, but we need timer with emulated 2D time. Hopefully this is enough
+	utils::AbstractTimer *timer(int milliseconds);
 signals:
 	void error(const QString &msg);
 	void log(const QString &msg);
@@ -102,7 +108,7 @@ private:
 	QDir mCurrentDir;
 	bool mIsExcerciseMode = false;
 	QStringList mInputs;
-
+	QVector<utils::AbstractTimer *> mTimers;
 };
 
 }

--- a/plugins/robots/interpreters/trikKitInterpreterCommon/src/trikbrick.cpp
+++ b/plugins/robots/interpreters/trikKitInterpreterCommon/src/trikbrick.cpp
@@ -36,6 +36,7 @@ TrikBrick::~TrikBrick()
 	qDeleteAll(mSensors);
 	qDeleteAll(mEncoders);
 	qDeleteAll(mLineSensors);
+	qDeleteAll(mTimers);
 }
 
 void TrikBrick::reset()
@@ -49,6 +50,11 @@ void TrikBrick::reset()
 	for (const auto &e : mEncoders) {
 		e->reset();
 	}
+	for (const auto &t : mTimers) {
+		t->stop();
+	}
+	qDeleteAll(mTimers);
+	mTimers.clear();
 	QMetaObject::invokeMethod(&mSensorUpdater, "stop"); // failproof against timer manipulation in another thread
 	//mSensorUpdater.stop(); /// maybe needed in other places too.
 }
@@ -317,6 +323,15 @@ QStringList TrikBrick::readAll(const QString &path)
 		result << QString::fromUtf8(line);
 	}
 
+	return result;
+}
+
+utils::AbstractTimer *TrikBrick::timer(int milliseconds)
+{
+	utils::AbstractTimer *result = mTwoDRobotModel->timeline().produceTimer();
+	mTimers.append(result);
+	result->setRepeatable(true); // seems to be the case
+	result->start(milliseconds);
 	return result;
 }
 

--- a/plugins/robots/utils/include/utils/abstractTimer.h
+++ b/plugins/robots/utils/include/utils/abstractTimer.h
@@ -27,14 +27,19 @@ class ROBOTS_UTILS_EXPORT AbstractTimer : public QObject
 public:
 	/// Returns true if the timer is working now or false otherwise
 	virtual bool isTicking() const = 0;
-	virtual void start() = 0;
-	virtual void start(int ms) = 0;
-	virtual void stop() = 0;
+	/// Alias for isTicking for ebtter symmetry with QTimer
+	virtual bool isActive() const { return isTicking(); }
+	virtual int interval() const = 0;
 	virtual void setInterval(int ms) = 0;
 
 	/// If \a repeatable then the timer will set itself up again when timeout reached.
 	/// By default timers are not repeatable.
 	virtual void setRepeatable(bool repeatable) = 0;
+
+public slots:
+	virtual void start() = 0;
+	virtual void start(int ms) = 0;
+	virtual void stop() = 0;
 
 signals:
 	void timeout();

--- a/plugins/robots/utils/include/utils/realTimer.h
+++ b/plugins/robots/utils/include/utils/realTimer.h
@@ -28,6 +28,7 @@ public:
 	RealTimer();
 
 	bool isTicking() const override;
+	int interval() const override;
 	void start() override;
 	void start(int ms) override;
 	void stop() override;

--- a/plugins/robots/utils/src/realTimer.cpp
+++ b/plugins/robots/utils/src/realTimer.cpp
@@ -27,6 +27,11 @@ bool RealTimer::isTicking() const
 	return mTimer.isActive();
 }
 
+int RealTimer::interval() const
+{
+	return mTimer.interval();
+}
+
 void RealTimer::start()
 {
 	start(mTimer.interval());


### PR DESCRIPTION
Sadly AbstractTimer's API is not 1 for 1 with QTimer, but it is close enough.

With this change, timers in js scripts created by script.timer() should be using 2d model time.